### PR TITLE
Shell documentation and naming updates

### DIFF
--- a/lib/nerves_runtime/shell.ex
+++ b/lib/nerves_runtime/shell.ex
@@ -15,9 +15,9 @@ defmodule Nerves.Runtime.Shell do
       2* {'Elixir.Nerves.Runtime.Shell',start,[]}
       --> c
       Nerves Interactive Host Shell
-      host[1]> find . -name "shell.ex"
+      sh[1]> find . -name "shell.ex"
       ./lib/nerves_runtime/shell.ex
-      host[2]> [Ctrl+G]
+      sh[2]> [Ctrl+G]
       User switch command
       --> c 1
 

--- a/lib/nerves_runtime/shell.ex
+++ b/lib/nerves_runtime/shell.ex
@@ -29,7 +29,7 @@ defmodule Nerves.Runtime.Shell do
 
   @doc """
   This is the callback invoked by Erlang's shell when someone presses Ctrl+G
-  and adds 's Elixir.Nerves.Host'.
+  and types `s Elixir.Nerves.Runtime.Shell`.
   """
   def start(opts \\ [], mfa \\ {Nerves.Runtime.Shell, :dont_display_result, []}) do
     spawn(fn ->

--- a/lib/nerves_runtime/shell.ex
+++ b/lib/nerves_runtime/shell.ex
@@ -28,7 +28,8 @@ defmodule Nerves.Runtime.Shell do
   alias Nerves.Runtime.Shell.Server
 
   @doc """
-  This is the callback invoked by Erlang's shell when someone presses Ctrl+G and adds 's Elixir.Nerves.Host'.
+  This is the callback invoked by Erlang's shell when someone presses Ctrl+G
+  and adds 's Elixir.Nerves.Host'.
   """
   def start(opts \\ [], mfa \\ {Nerves.Runtime.Shell, :dont_display_result, []}) do
     spawn(fn ->
@@ -38,7 +39,8 @@ defmodule Nerves.Runtime.Shell do
         _        -> :init.wait_until_started()
       end
 
-      # Make sure the OTP app fires up since we came in through the shell's job control mode.
+      # Make sure the OTP app fires up since we came in through the shell's
+      # job control mode.
       {:ok, _} = Application.ensure_all_started(:nerves_runtime)
       :io.setopts(Process.group_leader, binary: true, encoding: :unicode)
 

--- a/lib/nerves_runtime/shell.ex
+++ b/lib/nerves_runtime/shell.ex
@@ -1,6 +1,28 @@
 defmodule Nerves.Runtime.Shell do
   @moduledoc """
-  Entry point for a primitive host shell available through Erlang's job control mode.
+  Entry point for a primitive command shell available through Erlang's job
+  control mode. To use, type Ctrl+G at an iex prompt to enter job control mode.
+  At the prompt, type `s 'Elixir.Nerves.Runtime.Shell'` and then `c`` to
+  connect to it. To return to the iex prompt, type Ctrl+G again and `c 1`.
+
+  Here's an example session:
+
+      iex> [Ctrl+G]
+      User switch command
+      --> s 'Elixir.Nerves.Runtime.Shell'
+      --> j
+      1  {erlang,apply,[#Fun<Elixir.IEx.CLI.1.112225073>,[]]}
+      2* {'Elixir.Nerves.Runtime.Shell',start,[]}
+      --> c
+      Nerves Interactive Host Shell
+      host[1]> find . -name "shell.ex"
+      ./lib/nerves_runtime/shell.ex
+      host[2]> [Ctrl+G]
+      User switch command
+      --> c 1
+
+      nil
+      iex>
   """
 
   alias Nerves.Runtime.Shell.Server

--- a/lib/nerves_runtime/shell/evaluator.ex
+++ b/lib/nerves_runtime/shell/evaluator.ex
@@ -1,6 +1,7 @@
 defmodule Nerves.Runtime.Shell.Evaluator do
   @moduledoc """
-  The evaluator is responsible for managing the shell port and executing commands against it.
+  The evaluator is responsible for managing the shell port and executing
+  commands against it.
   """
 
   def init(command, server, leader, _opts) do

--- a/lib/nerves_runtime/shell/server.ex
+++ b/lib/nerves_runtime/shell/server.ex
@@ -19,9 +19,9 @@ defmodule Nerves.Runtime.Shell.Server do
   end
 
   defp run(opts) when is_list(opts) do
-    IO.puts "Nerves Interactive Host Shell"
+    IO.puts "Nerves Interactive Command Shell"
     evaluator = start_evaluator(opts)
-    state = %{counter: 1, prefix: "host"}
+    state = %{counter: 1, prefix: "sh"}
     loop(state, evaluator, Process.monitor(evaluator))
   end
 


### PR DESCRIPTION
This started as a collection of minor updates to the docs and then I renamed the shell prompt. As I think that you're aware, I have a personal bias against the word "host" so I attempted to find another word for the shell prompt. E.g., "sh", since the shell is hardcoded to "sh". In the future if the shell becomes configurable, naming the prompt after the program being run seemed reasonable. If this is controversial, I'll break this PR in two since the doc updates would be nice to have since I couldn't find info on starting the shell anywhere else.