### PR TITLE
Add missing device argument to handle_data_in callback in connection behaviour

### DIFF
--- a/lib/nerves_runtime/device/adapter/connection.ex
+++ b/lib/nerves_runtime/device/adapter/connection.ex
@@ -1,6 +1,6 @@
 defmodule Nerves.Runtime.Device.Adapter.Connection do
 
-  @callback handle_data_in(data :: any, state :: map) ::
-    {:noreply, state :: map} |
-    {:disconnect, state :: map}
+  @callback handle_data_in(device :: Device.t, data :: term, state :: term) ::
+    {:noreply, state :: term} |
+    {:disconnect, state :: term}
 end

--- a/lib/nerves_runtime/device/handler.ex
+++ b/lib/nerves_runtime/device/handler.ex
@@ -13,9 +13,6 @@ defmodule Nerves.Runtime.Device.Handler do
   @callback handle_disconnect(device :: Device.t, state :: term) ::
     {:noreply, new_state :: term}
 
-  @callback handle_data_in(device :: Device.t, data :: term, state :: term) ::
-    {:noreply, new_state :: term}
-
   @callback handle_call(call :: term, GenServer.from, state :: term) ::
     {:noreply, new_state :: term} |
     {:reply, reply :: term, new_state :: term}

--- a/lib/nerves_runtime/device/handler.ex
+++ b/lib/nerves_runtime/device/handler.ex
@@ -13,6 +13,9 @@ defmodule Nerves.Runtime.Device.Handler do
   @callback handle_disconnect(device :: Device.t, state :: term) ::
     {:noreply, new_state :: term}
 
+  @callback handle_data_in(device :: Device.t, data :: term, state :: term) ::
+    {:noreply, new_state :: term}
+
   @callback handle_call(call :: term, GenServer.from, state :: term) ::
     {:noreply, new_state :: term} |
     {:reply, reply :: term, new_state :: term}


### PR DESCRIPTION
I just noticed that this callback was missing from the device handler behaviour.  