### PR TITLE
Init and KV Workers

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -7,3 +7,5 @@ defmodule T do
     r Nerves.Runtime.Device
   end
 end
+
+alias Nerves.Runtime.KV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
 ## v0.3.0-dev
+  * Enhancements
+    * Removed GenStage in favor of SystemRegistry
+    * Added KV firmware variable key value store
+    * Added Init worker for initializing the application partition
 
 ## v0.2.0
-
-  * Moved hardware abstraction layer to separate project for further
+  * Enhancements
+    * Moved hardware abstraction layer to separate project for further
     development
-  * Start the shell using the name `sh` instead of `'Elixir.Nerves.Runtime.Shell'`
+    * Start the shell using the name `sh` instead of `'Elixir.Nerves.Runtime.Shell'`
 
 ## v0.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## v0.3.0-dev
+
 ## v0.2.0
 
   * Moved hardware abstraction layer to separate project for further

--- a/README.md
+++ b/README.md
@@ -3,19 +3,93 @@
 [![Build Status](https://travis-ci.org/nerves-project/nerves_runtime.svg)](https://travis-ci.org/nerves-project/nerves_runtime.svg)
 [![Hex version](https://img.shields.io/hexpm/v/nerves_runtime.svg "Hex version")](https://hex.pm/packages/nerves_runtime)
 
-Nerves.Runtime is an optional component of Nerves but it's really handy and has
-a small footprint. Here are some of its features:
+Nerves.Runtime is a core component of Nerves. It contains applications and
+libraries that are expected to be useful on all Nerves devices.  Here are some
+of its features:
 
+* Generic system and filesystem initialization (suitable for use with
+  [bootloader](https://github.com/nerves-project/bootloader)
+* Introspection of Nerves system firmware and deployment metadata
 * A custom shell for debugging and running commands in a `bash` shell like
   environment
 * A small Linux kernel `uevent` application for capturing hardware change events
   and more
 * More to come...
 
+The following sections describe the features in more detail. For even more
+information, consult the [hex docs](https://hexdocs.pm/nerves_runtime).
+
+## System initialization
+
+Nerves.Runtime provides an OTP application that can initialize the system when
+it is started. For this to be useful, Nerves.Runtime must be started before
+other OTP applications especially since non-Nerves-aware applications almost
+certainly won't know that they need this to work. Specific initialization is
+detailed in other sections. To set Nerves.Runtime up with `bootloader`, you will
+need to do the following (luckily this should become easier as this new
+functionality propagates through templates and examples.)
+
+1. Ensure that `bootloader` is included in your `mix.exs` and the
+   `Bootloader.Plugin` is in your `rel/config.exs`.
+2. In your `config/config.exs`, make sure that `:nerves_runtime` is at the
+   beginning of the `init:` list:
+```
+config :bootloader,
+  overlay_path: "",
+  init: [:nerves_runtime, :other_app],
+  app: :your_app
+```
+
+## Filesystem initialization
+
+Nerves systems generally ship with one or more application filesystem
+partitions. These are used for persisting data that's expected to live between
+firmware updates. The root filesystem cannot be used since it is mounted
+read-only in Nerves.
+
+Nerves.Runtime takes an unforgiving approach to managing the application
+partition: if it can't be mounted read-write, it gets re-formatted. While
+filesystem corruption should be a rare event even on unexpected powerdowns with
+modern filesystems, Nerves devices may not be easily accessed to perform any
+kind of recovery. This allows for at least some functionality.
+
+To verify that this recovery works, Nerves systems usually leave the application
+filesystems uninitialized so that the format operation happens on the first
+boot. This means that the first boot takes slightly longer than others.
+
+Note that a common implementation of "reset to factory" defaults is to
+purposefully corrupt the application partition and reboot.
+
+Nerves.Runtime uses firmware metadata to determine how to mount and initialize
+the application partition. The following variables are important:
+
+* `[partition].nerves_fw_application_part0_devpath` - the path to the
+  application partition. E.g., `/dev/mmcblk0p3`
+* `[partition].nerves_fw_application_part0_fstype` - the type of filesystem.
+  E.g., `ext4`
+* `[partition].nerves_fw_application_part0_target` - where the partition should
+  be mounted. E.g., `/root` or `/mnt/appdata`
+
+## Nerves system and firmware metadata
+
+All official Nerves systems maintain a short list of key-value pairs for
+tracking the running firmware version, etc. and other system information. This
+information is not intended to be written frequently. To get this information,
+call one of the following:
+
+* `Nerves.Runtime.KV.get_all_active/0` - return all key-value pairs associated
+  with the actively running firmware.
+* `Nerves.Runtime.KV.get_active/0` - return all key-value pairs. This includes
+  key-value pairs associated with the non-running firmware in an A/B partitioned
+  system.
+* `Nerves.Runtime.KV.get_active/1` - look up the value of a key associated with
+  the currently running firmware.
+* `Nerves.Runtime.KV.get/1` - look up the value of a key
+
 ## The Nerves Runtime Shell
 
 Nerves devices typically only expose an Elixir or Erlang shell prompt. While
-this is handy, so tasks are quicker to run in a more `bash` shell-like
+this is handy, some tasks are quicker to run in a more `bash` shell-like
 environment. The Nerves runtime shell provides a limited approximation to this
 that can be run without leaving the Erlang runtime. Here's an example run:
 

--- a/lib/nerves_runtime/application.ex
+++ b/lib/nerves_runtime/application.ex
@@ -11,6 +11,8 @@ defmodule Nerves.Runtime.Application do
     # Define workers and child supervisors to be supervised
     children = [
       supervisor(Nerves.Runtime.Kernel, []),
+      worker(Nerves.Runtime.KV, []),
+      worker(Nerves.Runtime.Init, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
@@ -18,4 +20,5 @@ defmodule Nerves.Runtime.Application do
     opts = [strategy: :one_for_one, name: Nerves.Runtime.Supervisor]
     Supervisor.start_link(children, opts)
   end
+
 end

--- a/lib/nerves_runtime/device.ex
+++ b/lib/nerves_runtime/device.ex
@@ -33,10 +33,7 @@ defmodule Nerves.Runtime.Device do
   end
 
   defp invoke_uevent_action(uevent, action) do
-    uevent
-    |> IO.inspect
-    |> File.write(action)
-    |> IO.inspect
+    File.write(uevent, action)
   end
 
 end

--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -13,16 +13,16 @@ defmodule Nerves.Runtime.Init do
 
   def init_application_partition() do
     prefix = "nerves_fw_application_part0"
-    fstype = KV.get_active("#{prefix}_fstype")
+    fstype = KV.get_active("#{prefix}_fstype") |> IO.inspect
     target = KV.get_active("#{prefix}_target")
     devpath = KV.get_active("#{prefix}_devpath")
     if  fstype  != nil
     and target  != nil
     and devpath != nil do
 
-      opts = %{fstype: fstype, target: target, devpath: devpath}
+      opts = %{mounted: nil, fstype: fstype, target: target, devpath: devpath}
       mounted_state = mounted_state(opts)
-      Map.put(opts, :mounted_state, mounted_state)
+      Map.put(opts, :mounted, mounted_state)
       |> unmount_if_error()
       |> mount()
       |> unmount_if_error()
@@ -35,7 +35,7 @@ defmodule Nerves.Runtime.Init do
   end
 
   def mounted_state(s) do
-    {mounts, 0} = System.cmd("mounts", [])
+    {mounts, 0} = System.cmd("mount", [])
     mount =
       String.split(mounts, "\n")
       |> Enum.find(fn(mount) ->
@@ -76,7 +76,7 @@ defmodule Nerves.Runtime.Init do
   defp unmount_if_error(s), do: s
 
   defp format_if_unmounted(%{mounted: :unmounted} = s) do
-    System.cmd("mkfs.#{s.fs_type}", ["#{s.devpath}", "-F"])
+    System.cmd("mkfs.#{s.fstype}", ["#{s.devpath}", "-F"])
     s
   end
 

--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -2,7 +2,7 @@ defmodule Nerves.Runtime.Init do
   use GenServer
   alias Nerves.Runtime.KV
 
-  def start_link do
+  def start_link() do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
@@ -11,16 +11,77 @@ defmodule Nerves.Runtime.Init do
     {:ok, %{}}
   end
 
-  def init_application_partition do
+  def init_application_partition() do
     prefix = "nerves_fw_application_part0"
-    fstype = KV.get("#{prefix}_fstype")
-    target = KV.get("#{prefix}_target")
-    devpath = KV.get("#{prefix}_devpath")
+    fstype = KV.get_active("#{prefix}_fstype")
+    target = KV.get_active("#{prefix}_target")
+    devpath = KV.get_active("#{prefix}_devpath")
     if  fstype  != nil
     and target  != nil
     and devpath != nil do
- #      System.cmd("mount", ["-t", fstype, "-o", "rw",
- # +      unquote(block_device), state_path])
+
+      opts = %{fstype: fstype, target: target, devpath: devpath}
+      mounted_state = mounted_state(opts)
+      Map.put(opts, :mounted_state, mounted_state)
+      |> unmount_if_error()
+      |> mount()
+      |> unmount_if_error()
+      |> format_if_unmounted()
+      |> mount()
+      |> validate_mount()
+    else
+      :noop
     end
   end
+
+  def mounted_state(s) do
+    {mounts, 0} = System.cmd("mounts", [])
+    mount =
+      String.split(mounts, "\n")
+      |> Enum.find(fn(mount) ->
+        String.starts_with?(mount, "#{s.devpath} on #{s.target}")
+      end)
+    mounted_state =
+      case mount do
+        nil -> :unmounted
+        mount ->
+          IO.inspect mount
+          opts =
+            String.split(mount, " ")
+            |> List.last
+            |> String.slice(1..-2)
+            |> String.split(",")
+            |> IO.inspect
+          cond do
+            "rw" in opts ->
+              :mounted
+            true ->
+              # Mount was read only or any other type
+              :mounted_with_error
+          end
+      end
+    %{s | mounted: mounted_state}
+  end
+
+  defp mount(%{mounted: :mounted} = s), do: s
+  defp mount(s) do
+    System.cmd("mount", ["-t", s.fstype, "-o", "rw", s.devpath, s.target])
+    mounted_state(s)
+  end
+
+  defp unmount_if_error(%{mounted: :mounted_with_error} = s) do
+    System.cmd("umount", [s.target])
+    mounted_state(s)
+  end
+  defp unmount_if_error(s), do: s
+
+  defp format_if_unmounted(%{mounted: :unmounted} = s) do
+    System.cmd("mkfs.#{s.fs_type}", ["#{s.devpath}", "-F"])
+    s
+  end
+
+  defp format_if_unmounted(s), do: s
+
+  defp validate_mount(s), do: s.mounted
+
 end

--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -1,0 +1,26 @@
+defmodule Nerves.Runtime.Init do
+  use GenServer
+  alias Nerves.Runtime.KV
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init([]) do
+    init_application_partition()
+    {:ok, %{}}
+  end
+
+  def init_application_partition do
+    prefix = "nerves_fw_application_part0"
+    fstype = KV.get("#{prefix}_fstype")
+    target = KV.get("#{prefix}_target")
+    devpath = KV.get("#{prefix}_devpath")
+    if  fstype  != nil
+    and target  != nil
+    and devpath != nil do
+ #      System.cmd("mount", ["-t", fstype, "-o", "rw",
+ # +      unquote(block_device), state_path])
+    end
+  end
+end

--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -47,19 +47,19 @@ defmodule Nerves.Runtime.Kernel.UEvent do
 
   def registry(%{"action" => "add", "devpath" => devpath} = event) do
     scope = scope(devpath)
-    Logger.debug "UEvent Add: #{inspect scope}"
+    #Logger.debug "UEvent Add: #{inspect scope}"
     attributes = Map.drop(event, ["action", "devpath"])
     SystemRegistry.update(scope(devpath), attributes)
   end
 
   def registry(%{"action" => "remove", "devpath" => devpath}) do
     scope = scope(devpath)
-    Logger.debug "UEvent Remove: #{inspect scope}"
+    #Logger.debug "UEvent Remove: #{inspect scope}"
     SystemRegistry.delete(scope)
   end
 
   def registry(%{"action" => "change"} = event) do
-    Logger.debug "UEvent Change: #{inspect event}"
+    #Logger.debug "UEvent Change: #{inspect event}"
     raw = Map.drop(event, ["action"])
     Map.put(raw, "action", "remove")
     |> registry
@@ -69,7 +69,7 @@ defmodule Nerves.Runtime.Kernel.UEvent do
   end
 
   def registry(%{"action" => "move", "devpath" => new, "devpath_old" => old}) do
-    Logger.debug "UEvent Move: #{inspect scope(old)} -> #{inspect scope(new)}"
+    #Logger.debug "UEvent Move: #{inspect scope(old)} -> #{inspect scope(new)}"
     SystemRegistry.move(scope(old), scope(new))
   end
 

--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -46,7 +46,7 @@ defmodule Nerves.Runtime.Kernel.UEvent do
   end
 
   def registry(%{"action" => "add", "devpath" => devpath} = event) do
-    scope = scope(devpath)
+    #scope = scope(devpath)
     #Logger.debug "UEvent Add: #{inspect scope}"
     attributes = Map.drop(event, ["action", "devpath"])
     SystemRegistry.update(scope(devpath), attributes)

--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -8,7 +8,7 @@ defmodule Nerves.Runtime.Kernel.UEvent do
   end
 
   def init([]) do
-    Logger.debug "Start UEvent Mon"
+    #Logger.debug "Start UEvent Mon"
     send(self(), :discover)
     executable = :code.priv_dir(:nerves_runtime) ++ '/uevent'
     port = Port.open({:spawn_executable, executable},

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -22,7 +22,7 @@ defmodule Nerves.Runtime.KV do
     GenServer.call(__MODULE__, :get_all)
   end
 
-  def init(kv) do
+  def init(_kv) do
     exec = System.find_executable("fw_printenv")
     s = load_kv(exec)
     {:ok, s}

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -1,0 +1,79 @@
+defmodule Nerves.Runtime.KV do
+  use GenServer
+  require Logger
+
+  def start_link(kv \\ "") do
+    GenServer.start_link(__MODULE__, kv, name: __MODULE__)
+  end
+
+  def get_active(key) do
+    GenServer.call(__MODULE__, {:get_active, key})
+  end
+
+  def get(key) do
+    GenServer.call(__MODULE__, {:get, key})
+  end
+
+  def get_all_active() do
+    GenServer.call(__MODULE__, :get_all_active)
+  end
+
+  def get_all() do
+    GenServer.call(__MODULE__, :get_all)
+  end
+
+  def init(kv) do
+    exec = System.find_executable("fw_printenv")
+    s = load_kv(exec)
+    {:ok, s}
+  end
+
+  def handle_call({:get_active, key}, _from, s) do
+    {:reply, active(key, s), s}
+  end
+
+  def handle_call({:get, key}, _from, s) do
+    {:reply, Map.get(s, key), s}
+  end
+
+  def handle_call(:get_all_active, _from, s) do
+    active = active(s) <> "."
+    reply =
+      Enum.filter(s, fn({k, _}) ->
+        String.starts_with?(k, active)
+      end)
+      |> Enum.into(%{})
+    {:reply, reply, s}
+  end
+
+  def handle_call(:get_all, _from, s) do
+    {:reply, s, s}
+  end
+
+  def load_kv(nil), do: %{}
+  def load_kv(exec) do
+    case System.cmd(exec, []) do
+      {result, 0} ->
+        parse_kv(result)
+      _ ->
+        Logger.warn "#{inspect __MODULE__} could not find executable fw_printenv"
+        %{}
+    end
+  end
+
+  def parse_kv(str) do
+    String.split(str, "\n")
+    |> Enum.map(& String.split(&1, "="))
+    |> Enum.reduce(%{}, fn
+      ([k, v], acc) ->
+        Map.put(acc, k, v)
+      (_, acc) -> acc
+    end)
+  end
+
+  def active(s), do: Map.get(s, "nerves_fw_active", "")
+  def active(key, s) do
+    "#{active(s)}.#{key}"
+  end
+
+end

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -73,7 +73,7 @@ defmodule Nerves.Runtime.KV do
 
   def active(s), do: Map.get(s, "nerves_fw_active", "")
   def active(key, s) do
-    "#{active(s)}.#{key}"
+    Map.get(s, "#{active(s)}.#{key}")
   end
 
 end

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -38,11 +38,7 @@ defmodule Nerves.Runtime.KV do
 
   def handle_call(:get_all_active, _from, s) do
     active = active(s) <> "."
-    reply =
-      Enum.filter(s, fn({k, _}) ->
-        String.starts_with?(k, active)
-      end)
-      |> Enum.into(%{})
+    reply = filter_trim_active(s, active)
     {:reply, reply, s}
   end
 
@@ -74,6 +70,14 @@ defmodule Nerves.Runtime.KV do
   def active(s), do: Map.get(s, "nerves_fw_active", "")
   def active(key, s) do
     Map.get(s, "#{active(s)}.#{key}")
+  end
+
+  def filter_trim_active(s, active) do
+    Enum.filter(s, fn({k, _}) ->
+      String.starts_with?(k, active)
+    end)
+    |> Enum.map(fn({k, v}) -> {String.replace_leading(k, active, ""), v} end)
+    |> Enum.into(%{})
   end
 
 end

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -1,26 +1,65 @@
 defmodule Nerves.Runtime.KV do
+  @moduledoc """
+  Key Value Storage for firmware vairables provided by fwup
+
+  KV provides access to metadata variables set by fwup.
+  It can be used to obtain information such as the active
+  firmware slot, where the application data partition
+  is located, etc.
+
+  Values are stored in two ways.
+  * Values do not pertain to a specific firmware slot
+  For example:
+    `"nerves_fw_active" => "a"`
+
+  * Values pretain to a specific firmware slot
+  For Example:
+    `"a.nerves_fw_author" => "The Nerves Team"`
+
+  You can find values for just the active firmware slot by
+  using get_active and get_all_active. The result of these
+  functions will trim the firmware slot "a." or "b." off the
+  from the leading characters of the keys returned.
+  """
   use GenServer
   require Logger
 
+  @doc """
+  Start the KV store server
+  """
   def start_link(kv \\ "") do
     GenServer.start_link(__MODULE__, kv, name: __MODULE__)
   end
 
+  @doc """
+  Get the key for only the active firmware slot
+  """
   def get_active(key) do
     GenServer.call(__MODULE__, {:get_active, key})
   end
 
+  @doc """
+  get the key regardless of firmware slot
+  """
   def get(key) do
     GenServer.call(__MODULE__, {:get, key})
   end
 
+  @doc """
+  Get all key value pairs for only the active firmware slot
+  """
   def get_all_active() do
     GenServer.call(__MODULE__, :get_all_active)
   end
 
+  @doc """
+  Get all keys regardless of firmware slot
+  """
   def get_all() do
     GenServer.call(__MODULE__, :get_all)
   end
+
+  # GenServer API
 
   def init(_kv) do
     exec = System.find_executable("fw_printenv")

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Nerves.Runtime.Mixfile do
 
   def project do
     [app: :nerves_runtime,
-     version: "0.2.0",
+     version: "0.3.0-dev",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/test/init_test.exs
+++ b/test/init_test.exs
@@ -1,0 +1,21 @@
+defmodule InitTest do
+  use ExUnit.Case
+  doctest Nerves.Runtime.Init
+
+  alias Nerves.Runtime.Init
+
+  # test "mounted?" do
+  #   mounts =
+  #     """
+  #     sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
+  #     proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
+  #     udev on /dev type devtmpfs (rw,nosuid,relatime,size=1979780k,nr_inodes=494945,mode=755)
+  #     devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000)
+  #     tmpfs on /run type tmpfs (ro,nosuid,noexec,relatime,size=400008k,mode=755)
+  #     /dev/sda1 on / type ext4 (rw,relatime,errors=remount-ro,data=ordered)
+  #     """
+  #   assert Init.mounted_state("/dev/sda1", "/", mounts) == :mounted
+  #   assert Init.mounted_state("tmpfs", "/run", mounts) == :mounted_with_error
+  #   assert Init.mounted_state("dsfds", "fggvef", mounts) == :unmounted
+  # end
+end

--- a/test/init_test.exs
+++ b/test/init_test.exs
@@ -2,7 +2,7 @@ defmodule InitTest do
   use ExUnit.Case
   doctest Nerves.Runtime.Init
 
-  alias Nerves.Runtime.Init
+  #alias Nerves.Runtime.Init
 
   # test "mounted?" do
   #   mounts =

--- a/test/kv_test.exs
+++ b/test/kv_test.exs
@@ -1,0 +1,33 @@
+defmodule KVTest do
+  use ExUnit.Case
+  doctest Nerves.Runtime.KV
+
+  alias Nerves.Runtime.KV
+
+  test "parse kv" do
+    kv_raw =
+      """
+      a.nerves_fw_application_part0_devpath=/dev/mmcblk0p3
+      a.nerves_fw_application_part0_fstype=ext4
+      a.nerves_fw_application_part0_target=/root
+      a.nerves_fw_architecture=arm
+      a.nerves_fw_author=The Nerves Team
+      a.nerves_fw_description=
+      a.nerves_fw_platform=rpi
+      a.nerves_fw_product=Nerves Firmware
+      a.nerves_fw_version=
+      nerves_fw_active=a
+      nerves_fw_devpath=/dev/mmcblk0
+      """
+    kv =
+      %{"a.nerves_fw_application_part0_devpath" => "/dev/mmcblk0p3",
+        "a.nerves_fw_application_part0_fstype" => "ext4",
+        "a.nerves_fw_application_part0_target" => "/root",
+        "a.nerves_fw_architecture" => "arm",
+        "a.nerves_fw_author" => "The Nerves Team", "a.nerves_fw_description" => "",
+        "a.nerves_fw_platform" => "rpi", "a.nerves_fw_product" => "Nerves Firmware",
+        "a.nerves_fw_version" => "", "nerves_fw_active" => "a",
+        "nerves_fw_devpath" => "/dev/mmcblk0"}
+    assert KV.parse_kv(kv_raw) == kv
+  end
+end


### PR DESCRIPTION
Adds Init and KV workers. Supports formatting application data partitions by reading from the uboot env block provided fwd from the fwup.conf