### PR TITLE
Move powerdown utils from Nerves.Firmware to here

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ of its features:
 * Introspection of Nerves system firmware and deployment metadata
 * A custom shell for debugging and running commands in a `bash` shell like
   environment
+* Device reboot and shutdown
 * A small Linux kernel `uevent` application for capturing hardware change events
   and more
 * More to come...
@@ -85,6 +86,17 @@ call one of the following:
 * `Nerves.Runtime.KV.get_active/1` - look up the value of a key associated with
   the currently running firmware.
 * `Nerves.Runtime.KV.get/1` - look up the value of a key
+
+## Device reboot and shutdown
+
+Reboot, poweroff, and halting a device work by signaling to
+[erlinit](https://github.com/nerves-project/erlinit) an intention to shutdown
+and then exiting the Erlang VM by calling `:init.stop/0`. The
+`Nerves.Runtime.reboot/0` and related utilities are helper methods for this.
+Once they return, the Erlang VM will likely only be available momentarily before
+shutdown. If the OTP applications cannot be stopped within a timeout as
+specified in the `erlinit.config`, `erlinit` will ungracefully terminate the
+Erlang VM.
 
 ## The Nerves Runtime Shell
 

--- a/lib/nerves_runtime.ex
+++ b/lib/nerves_runtime.ex
@@ -1,3 +1,44 @@
 defmodule Nerves.Runtime do
-  
+  require Logger
+
+  @moduledoc """
+
+  """
+
+  @doc """
+  Reboot the device and gracefully shutdown the Erlang VM.
+  """
+  @spec reboot() :: :ok
+  def reboot(), do: logged_shutdown "reboot"
+
+  @doc """
+  Power off the device.
+  """
+  @spec poweroff() :: :ok
+  def poweroff(), do: logged_shutdown "poweroff"
+
+  @doc """
+  Halt the device (meaning hang, not power off, nor reboot).
+
+  Note: this is different than :erlang.halt(), which exits BEAM, and
+  may end up rebooting the device if `erlinit.config` settings allow reboot on exit.
+  """
+  @spec halt() :: :ok
+  def halt(), do: logged_shutdown "halt"
+
+  # private helpers
+
+  defp logged_shutdown(cmd) do
+    Logger.info "#{__MODULE__} : device told to #{cmd}"
+
+    # Invoke the appropriate command to tell erlinit that a shutdown
+    # of the Erlang VM is imminent. Once this returns, the Erlang has
+    # about 10 seconds to exit unless `--graceful-powerdown` is used
+    # in the `erlinit.config` to modify the timeout.
+    System.cmd(cmd, [])
+
+    # Gracefully shut down
+    :init.stop
+  end
+
 end


### PR DESCRIPTION
Nerves.Runtime is a more logical place for finding the utilities. The utilities still exist in Nerves.Firmware for applications that still need them.