### PR TITLE
Subsystems and modalias

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ functionality propagates through templates and examples.)
    `Bootloader.Plugin` is in your `rel/config.exs`.
 2. In your `config/config.exs`, make sure that `:nerves_runtime` is at the
    beginning of the `init:` list:
+
 ```elixir
 config :bootloader,
   overlay_path: "",
   init: [:nerves_runtime, :other_app],
   app: :your_app
 ```
+
 ### Kernel Modules
 
 Nerves.Runtime will attempt to autoload kernel modules by calling `modprobe`
@@ -48,7 +50,7 @@ disable this feature by configuring `autoload: false` in your application config
 
 ```elixir
 config :nerves_runtime, :kernel,
-  autoload: false
+  autoload_modules: false
 ```
 
 ## Filesystem initialization

--- a/README.md
+++ b/README.md
@@ -34,11 +34,21 @@ functionality propagates through templates and examples.)
    `Bootloader.Plugin` is in your `rel/config.exs`.
 2. In your `config/config.exs`, make sure that `:nerves_runtime` is at the
    beginning of the `init:` list:
-```
+```elixir
 config :bootloader,
   overlay_path: "",
   init: [:nerves_runtime, :other_app],
   app: :your_app
+```
+### Kernel Modules
+
+Nerves.Runtime will attempt to autoload kernel modules by calling `modprobe`
+using the `modalias` supplied from the uevent message for devices. You can
+disable this feature by configuring `autoload: false` in your application config.
+
+```elixir
+config :nerves_runtime, :kernel,
+  autoload: false
 ```
 
 ## Filesystem initialization

--- a/lib/nerves_runtime/kernel.ex
+++ b/lib/nerves_runtime/kernel.ex
@@ -7,8 +7,9 @@ defmodule Nerves.Runtime.Kernel do
   end
 
   def init([]) do
+    kernel_opts = Application.get_env(:nerves_runtime, :kernel)
     children = [
-      worker(Kernel.UEvent, [])
+      worker(Kernel.UEvent, [kernel_opts])
     ]
 
     supervise(children, strategy: :one_for_one)

--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -8,7 +8,7 @@ defmodule Nerves.Runtime.Kernel.UEvent do
   end
 
   def init(opts) do
-    autoload = if opts[:autoload] != nil, do: opts[:autoload], else: true
+    autoload = if opts[:autoload_modules] != nil, do: opts[:autoload_modules], else: true
     send(self(), :discover)
     executable = :code.priv_dir(:nerves_runtime) ++ '/uevent'
     port = Port.open({:spawn_executable, executable},

--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -99,11 +99,10 @@ defmodule Nerves.Runtime.Kernel.UEvent do
   end
 
   defp subsystem_scope(subsystem) do
-    [:state, :subsystems, subsystem]
+    [:state, "subsystems", subsystem]
   end
 
   defp modprobe(%{"modalias" => modalias}) do
-    IO.inspect "here"
     System.cmd("modprobe", [modalias], stderr_to_stdout: true)
   end
   defp modprobe(_), do: :noop

--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -3,12 +3,12 @@ defmodule Nerves.Runtime.Kernel.UEvent do
   require Logger
   alias Nerves.Runtime.Device
 
-  def start_link() do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
-  def init([]) do
-    #Logger.debug "Start UEvent Mon"
+  def init(opts) do
+    autoload = if opts[:autoload] != nil, do: opts[:autoload], else: true
     send(self(), :discover)
     executable = :code.priv_dir(:nerves_runtime) ++ '/uevent'
     port = Port.open({:spawn_executable, executable},
@@ -18,20 +18,20 @@ defmodule Nerves.Runtime.Kernel.UEvent do
       :binary,
       :exit_status])
 
-    {:ok, %{port: port}}
+    {:ok, %{port: port, autoload: autoload}}
   end
 
-  def handle_info(:discover, state) do
+  def handle_info(:discover, s) do
     Device.discover
-    {:noreply, state}
+    {:noreply, s}
   end
 
-  def handle_info({_, {:data, <<?n, message::binary>>}}, state) do
+  def handle_info({_, {:data, <<?n, message::binary>>}}, s) do
     msg = :erlang.binary_to_term(message)
-    handle_port(msg, state)
+    handle_port(msg, s)
   end
 
-  defp handle_port({:uevent, _uevent, kv}, state) do
+  defp handle_port({:uevent, _uevent, kv}, s) do
     event =
       Enum.reduce(kv, %{}, fn (str, acc) ->
         [k, v] = String.split(str, "=")
@@ -39,41 +39,55 @@ defmodule Nerves.Runtime.Kernel.UEvent do
         Map.put(acc, k, v)
       end)
     case Map.get(event, "devpath", "") do
-      "/devices" <> _path -> registry(event)
+      "/devices" <> _path -> registry(event, s)
       _ -> :noop
     end
-    {:noreply, state}
+    {:noreply, s}
   end
 
-  def registry(%{"action" => "add", "devpath" => devpath} = event) do
-    #scope = scope(devpath)
-    #Logger.debug "UEvent Add: #{inspect scope}"
+  def registry(%{"action" => "add", "devpath" => devpath} = event, s) do
     attributes = Map.drop(event, ["action", "devpath"])
-    SystemRegistry.update(scope(devpath), attributes)
+    scope = scope(devpath)
+    #Logger.debug "UEvent Add: #{inspect scope}"
+    if subsystem = Map.get(event, "subsystem") do
+      SystemRegistry.update_in(subsystem_scope(subsystem), fn(v) ->
+        v = if is_nil(v), do: [], else: v
+        [scope | v]
+      end)
+    end
+    if s.autoload, do: modprobe(event)
+    SystemRegistry.update(scope, attributes)
   end
 
-  def registry(%{"action" => "remove", "devpath" => devpath}) do
+  def registry(%{"action" => "remove", "devpath" => devpath} = event, _) do
     scope = scope(devpath)
     #Logger.debug "UEvent Remove: #{inspect scope}"
     SystemRegistry.delete(scope)
+    if subsystem = Map.get(event, "subsystem") do
+      SystemRegistry.update_in(subsystem_scope(subsystem), fn(v) ->
+        v = if is_nil(v), do: [], else: v
+        {_, scopes} = Enum.split_with(v, fn(v) -> v == scope end)
+        scopes
+      end)
+    end
   end
 
-  def registry(%{"action" => "change"} = event) do
+  def registry(%{"action" => "change"} = event, s) do
     #Logger.debug "UEvent Change: #{inspect event}"
     raw = Map.drop(event, ["action"])
     Map.put(raw, "action", "remove")
-    |> registry
+    |> registry(s)
 
     Map.put(raw, "action", "add")
-    |> registry
+    |> registry(s)
   end
 
-  def registry(%{"action" => "move", "devpath" => new, "devpath_old" => old}) do
+  def registry(%{"action" => "move", "devpath" => new, "devpath_old" => old}, _) do
     #Logger.debug "UEvent Move: #{inspect scope(old)} -> #{inspect scope(new)}"
     SystemRegistry.move(scope(old), scope(new))
   end
 
-  def registry(event) do
+  def registry(event, _) do
     Logger.debug "UEvent Unhandled: #{inspect event}"
   end
 
@@ -83,5 +97,15 @@ defmodule Nerves.Runtime.Kernel.UEvent do
   defp scope(devpath) do
     [:state | String.split(devpath, "/")]
   end
+
+  defp subsystem_scope(subsystem) do
+    [:state, :subsystems, subsystem]
+  end
+
+  defp modprobe(%{"modalias" => modalias}) do
+    IO.inspect "here"
+    System.cmd("modprobe", [modalias], stderr_to_stdout: true)
+  end
+  defp modprobe(_), do: :noop
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Nerves.Runtime.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [{:elixir_make, "~> 0.4", runtime: false},
-     {:system_registry, github: "mobileoverlord/system_registry"},
+     {:system_registry, "~> 0.3.0"},
      {:ex_doc, "~> 0.11", only: :dev}]
 end
 
@@ -45,7 +45,7 @@ end
   end
 
   defp package do
-    [maintainers: ["Frank Hunleth", "Garth Hitchens", "Justin Schneck", "Greg Mefford"],
+    [maintainers: ["Frank Hunleth", "Justin Schneck", "Greg Mefford"],
      files: ["lib", "LICENSE", "mix.exs", "README.md", "src/*.[ch]", "Makefile"],
      licenses: ["Apache 2.0"],
      links: %{"Github" => "https://github.com/nerves-project/nerves"}]

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
   "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "system_registry": {:git, "https://github.com/mobileoverlord/system_registry.git", "a6265f566a7b46cb282487d8e81027e3cb1a40d6", []}}
+  "system_registry": {:hex, :system_registry, "0.3.0", "31a748d0445984622359b901f2b4cdcd25457eeee9be881310590e3cd553f017", [:mix], []}}

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{"earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
   "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
-  "system_registry": {:git, "https://github.com/mobileoverlord/system_registry.git", "7f428357be4c448db58fcc48f225a529f805cd5c", []}}
+  "system_registry": {:git, "https://github.com/mobileoverlord/system_registry.git", "a6265f566a7b46cb282487d8e81027e3cb1a40d6", []}}


### PR DESCRIPTION
system_registry 0.3.0 adds update_in/3 which lets us reasonably maintain lists as values. This means that we can logically represent the devices in the systems as both 
` [:state, "devices", "platform", "i8042", "serio0", "input", "input1", "input1::capslock"]`
and aliased in its subsystem
```
[:state, "subsystems", "leds"] -> [[:state, "devices", "platform", "i8042", "serio0", "input", "input1", "input1::capslock"]]
```

`modprobe` will be called on the uevent `modalias` if it exists by default. Added functionality to disable autoload through the application configuration.

```elixir
config :nerves_runtime, :kernel,
  autoload_modules: false
```
