### PR TITLE
Fix mounted_state initialization

### DIFF
--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -21,8 +21,7 @@ defmodule Nerves.Runtime.Init do
     and devpath != nil do
 
       opts = %{mounted: nil, fstype: fstype, target: target, devpath: devpath}
-      mounted_state = mounted_state(opts)
-      Map.put(opts, :mounted, mounted_state)
+      mounted_state(opts)
       |> unmount_if_error()
       |> mount()
       |> unmount_if_error()


### PR DESCRIPTION
It was already added to the opts map, so adding it again just messed it
up. This fixes a failed mount that luckily would get ignored at
initialization except for a print message.