### PR TITLE
increase message size to 2048

### DIFF
--- a/src/erlcmd.h
+++ b/src/erlcmd.h
@@ -24,7 +24,7 @@
 /*
  * Erlang request/response processing
  */
-#define ERLCMD_BUF_SIZE 1024
+#define ERLCMD_BUF_SIZE 2048
 struct erlcmd
 {
     char buffer[ERLCMD_BUF_SIZE];


### PR DESCRIPTION
Work around message size segfaults for when receiving uevent messages with many attributes / long modalias names