### PR TITLE
Add IEx helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Here are some of its features:
 * Device reboot and shutdown
 * A small Linux kernel `uevent` application for capturing hardware change events
   and more
+* IEx helpers to make life better when working from the IEx prompt
 * More to come...
 
 The following sections describe the features in more detail. For even more
@@ -226,6 +227,31 @@ There are a few caveats to using this shell for now:
     regular shell. For most commands, it's harmless. One side effect is that if
     a command changes the current directory, it could be that the prompt shows
     the wrong path.
+
+## IEx helpers
+
+The `Nerves.Runtime.Helpers` module provides a number of functions that are
+useful when working at the IEx prompt on a target. They include:
+
+* `cmd/1` - runs a shell command and prints the output
+* `hex/1` - inspects a value in hexadecimal mode
+* `reboot/0` - reboots gracefully
+* `reboot!/0 ` - reboots immediately
+
+More information is available in the module docs for `Nerves.Runtime.Helpers`
+and through `h/1`.
+
+The IEx helpers aren't loaded by default. To use them, run the following:
+```
+iex> use Nerves.Runtime.Helpers
+```
+
+If you expect to use them frequently, add them to your `.iex.exs` on the
+target by running:
+
+```
+iex> File.write!("/root/.iex.exs", "use Nerves.Runtime.Helpers")
+```
 
 ## Installation
 

--- a/lib/nerves_runtime/helpers.ex
+++ b/lib/nerves_runtime/helpers.ex
@@ -1,0 +1,73 @@
+defmodule Nerves.Runtime.Helpers do
+  @moduledoc """
+  Helper functions for making the IEx prompt a little friendlier to use
+  with Nerves. It is intended to be imported to minimize typing:
+
+      iex> use Nerves.Runtime.Helpers
+
+  For development, you may want to run
+
+      iex> File.write!("/root/.iex.exs", "use Nerves.Runtime.Helpers")
+
+  on the target so that it gets imported automatically.
+
+  Helpers include:
+
+   * `cmd/1`     - runs a shell command and prints the output
+   * `hex/1`     - inspects a value with integers printed as hex
+   * `reboot/0`  - reboots gracefully
+   * `reboot!/0` - reboots immediately
+
+  Help for all of these can be found by running:
+
+      iex> h(Nerves.Runtime.Helpers.cmd/1)
+
+  """
+
+  defmacro __using__(_) do
+    quote do
+      import Nerves.Runtime.Helpers
+      IO.puts("Nerves.Runtime.Helpers imported. Run h(Nerves.Runtime.Helpers) for more info")
+    end
+  end
+
+  @doc """
+  Run a command using :os.cmd/1 and run its output
+  through IO.puts so that newlines get printed nicely.
+  """
+  def cmd(str) when is_binary(str) do
+    cmd(to_charlist(str))
+  end
+  def cmd(str) when is_list(str) do
+    :os.cmd(str) |> IO.puts
+  end
+
+  @doc """
+  Shortcut to reboot a board. This is a graceful reboot, so it takes
+  some time before the real reboot.
+  """
+  defdelegate reboot(), to: Nerves.Runtime
+
+  @doc """
+  Remote immediately without a graceful shutdown. This is for the
+  impatient.
+  """
+  def reboot!() do
+    Nerves.Runtime.reboot()
+    :erlang.halt()
+  end
+
+  @doc """
+  Inspect a value with all integers printed out in hex. This is useful
+  for one-off hex conversions. If you're doing a lot of work that requires
+  hexadecimal output, you should consider running:
+
+  `IEx.configure(inspect: [base: :hex])`
+
+  The drawback of doing the above is that strings print out as hex binaries.
+  """
+  def hex(value) do
+    inspect(value, base: :hex)
+  end
+
+end


### PR DESCRIPTION
These are some utilities that I like to use at IEx prompt when running Nerves. There's certainly more that can be added, but I wanted to get started with some simple ones to get a feel for what people thought.

Here's some of the logic:
1. How many times have you typed `:os.cmd('dmesg')` only to forget to `|> IO.puts` so that the output is readable? `cmd/1` fixes that. It also fixes an issue that happens to me every time switch back and forth to Erlang which is that my fingers type double quotes instead of single quotes.
2. Lots of numbers and binaries I work with are more easily read in hex. See the `hex/1` utility.
3. Graceful reboot is cool, but sometimes I don't want to wait. Therefore, `reboot!/0`.

Also, @mobileoverlord tells me that he's working on a fix to IEx so that `h cmd` works. Currently, you have to run `h Nerves.Runtime.Helpers.cmd`, etc.