### PR TITLE
Force UUID on application partition

### DIFF
--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -1,6 +1,19 @@
 defmodule Nerves.Runtime.Init do
   use GenServer
+  require Logger
   alias Nerves.Runtime.KV
+
+  # Use a fixed UUID for the application partition. This has two
+  # purposes:
+  #
+  #   1. mkfs.ext4 calls generate_uuid which calls getrandom(). That
+  #      call can block indefinitely until the urandom pool has been
+  #      initialized. This will delay startup for a long time if the
+  #      app partition needs to be reformated. (mkfs.ext4 has two calls
+  #      to getrandom() so this only fixes one of them.)
+  #   2. Applications that would prefer to look up a partition by UUID
+  #      can do so.
+  @app_partition_uuid "3041e38d-615b-48d4-affb-a7787b5c4c39"
 
   def start_link() do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
@@ -73,7 +86,8 @@ defmodule Nerves.Runtime.Init do
   defp unmount_if_error(s), do: s
 
   defp format_if_unmounted(%{mounted: :unmounted} = s) do
-    System.cmd("mkfs.#{s.fstype}", ["-F", "#{s.devpath}"])
+    Logger.warn("Formatting application partition. If this hangs, it could be waiting on the urandom pool to be initialized")
+    System.cmd("mkfs.#{s.fstype}", ["-U", @app_partition_uuid, "-F", "#{s.devpath}"])
     s
   end
 


### PR DESCRIPTION
This works around an issue with newer versions of util-linux that now
call the blocking getrandom(). This can hold up formatting of the
application partition indefinitely, which then holds up network
initialization. All of this for UUID generation (and a hash table seed).