### PR TITLE
Add a basic syslog and kmsg tailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## v0.5.3
+  * Enchancements
+    * Forward operating system messages from `/dev/log` and `/proc/kmsg` to
+      Elixir's `Logger`.
 
   * Bug Fixes
     * `Nerves.Runtime.revert` would always reboot even if told not to.

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifeq ($(CROSSCOMPILE),)
 	DEFAULT_TARGETS = priv
     endif
 endif
-DEFAULT_TARGETS ?= priv priv/uevent
+DEFAULT_TARGETS ?= priv priv/uevent priv/log_tailer
 
 # Look for the EI library and header files
 # For crosscompiled builds, ERL_EI_INCLUDE_DIR and ERL_EI_LIBDIR must be
@@ -76,5 +76,8 @@ priv/uevent: src/uevent.o src/erlcmd.o
 	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
 	$(call update_perms, $@)
 
+priv/log_tailer: src/log_tailer.o
+	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
+
 clean:
-	rm -f priv/uevent src/*.o
+	rm -f priv/uevent priv/log_tailer src/*.o

--- a/README.md
+++ b/README.md
@@ -226,6 +226,20 @@ target by running:
 iex> File.write!("/root/.iex.exs", "use Nerves.Runtime.Helpers")
 ```
 
+## Operating system log collection
+
+Operating system-level messages from `/dev/log` and `/proc/kmsg`, forwarding
+them to `Logger` with an appropriate level to match the syslog priority parsed
+out of the message.
+
+You can disable this feature (e.g. when running in CI) by configuring the
+following option:
+
+```elixir
+# config.exs
+config :nerves_runtime, enable_syslog: false
+```
+
 ## Installation
 
 The package can be installed by adding `nerves_runtime` to your list of

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,3 @@
 use Mix.Config
+
+config :nerves_runtime, :enable_syslog, Mix.env() != :test

--- a/lib/nerves_runtime/application.ex
+++ b/lib/nerves_runtime/application.ex
@@ -3,13 +3,22 @@ defmodule Nerves.Runtime.Application do
 
   use Application
 
+  alias Nerves.Runtime.{
+    Init,
+    Kernel,
+    KV,
+    LogTailer,
+  }
+
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
     children = [
-      supervisor(Nerves.Runtime.Kernel, []),
-      worker(Nerves.Runtime.KV, []),
-      worker(Nerves.Runtime.Init, [])
+      worker(LogTailer.Syslog, []),
+      worker(LogTailer.Kmsg, []),
+      supervisor(Kernel, []),
+      worker(KV, []),
+      worker(Init, [])
     ]
 
     opts = [strategy: :one_for_one, name: Nerves.Runtime.Supervisor]

--- a/lib/nerves_runtime/log_tailer.ex
+++ b/lib/nerves_runtime/log_tailer.ex
@@ -1,0 +1,170 @@
+defmodule Nerves.Runtime.LogTailer do
+  @moduledoc """
+  Collects operating system-level messages from `/dev/log` and `/proc/kmsg`,
+  forwarding them to `Logger` with an appropriate level to match the syslog
+  priority parsed out of the message.
+
+  You can disable this feature (e.g. for testing) by configuring the following
+  option:
+
+  ```elixir
+  # config.exs
+  config :nerves_runtime, enable_syslog: false
+  ```
+  """
+
+  use GenServer
+
+  require Logger
+
+  @port_binary_name "log_tailer"
+
+  @doc false
+  def gen_server_name(:syslog), do: __MODULE__.Syslog
+  def gen_server_name(:kmsg), do: __MODULE__.Kmsg
+
+  @type type :: :syslog | :kmsg
+
+  @doc """
+  `type` must be `:syslog` or `:kmsg` to indicate which log to tail with this
+  process. They're managed by separate processes, both to isolate failures and
+  to simplify the handling of messages being sent back from the ports.
+  """
+  @spec start_link(:syslog | :kmsg) :: {:ok, pid()}
+  def start_link(type) do
+    enabled = Application.get_env(:nerves_runtime, :enable_syslog, true)
+    GenServer.start_link(__MODULE__, %{type: type, enabled: enabled}, name: gen_server_name(type))
+  end
+
+  @spec init(%{type: :syslog | :kmsg, enabled: boolean()}) ::
+          {:ok, %{type: atom(), port: port(), buffer: binary()}}
+  def init(%{enabled: false}), do: :ignore
+  def init(%{type: type}), do: {:ok, %{type: type, port: open_port(type), buffer: ""}}
+
+  def handle_info({port, {:data, {:noeol, fragment}}}, %{port: port, buffer: buffer} = state) do
+    {:noreply, %{state | buffer: buffer <> fragment}}
+  end
+
+  def handle_info(
+        {port, {:data, {:eol, fragment}}},
+        %{type: type, port: port, buffer: buffer} = state
+      ) do
+    handle_message(type, buffer <> fragment)
+    {:noreply, %{state | buffer: ""}}
+  end
+
+  defp open_port(type) do
+    Port.open({:spawn_executable, executable()}, [
+      {:args, [to_string(type)]},
+      {:line, 1024},
+      :use_stdio,
+      :binary,
+      :exit_status
+    ])
+  end
+
+  defp executable() do
+    :nerves_runtime
+    |> :code.priv_dir()
+    |> Path.join(@port_binary_name)
+  end
+
+  defp handle_message(type, data) do
+    case parse_syslog_message(data) do
+      %{facility: facility, severity: severity, message: message} ->
+        Logger.bare_log(
+          logger_level(severity),
+          message,
+          module: gen_server_name(type),
+          facility: facility,
+          severity: severity
+        )
+
+      _ ->
+        # This is unlikely to ever happen, but if a message was somehow
+        # malformed and we couldn't parse the syslog priority, we should
+        # still do a best-effort to pass along the raw data.
+        Logger.bare_log(:info, data, module: gen_server_name(type))
+    end
+  end
+
+  @doc """
+  Parse out the syslog facility, severity, and message (including the timestamp
+  and host) from a syslog-formatted string.
+  """
+  @spec parse_syslog_message(binary()) ::
+          %{facility: atom(), severity: atom(), message: binary()}
+          | {:error, :not_syslog_format}
+  def parse_syslog_message(data) do
+    case Regex.named_captures(~r/^<(?<pri>\d{1,3})>(?<message>.*)$/, data) do
+      %{"pri" => pri, "message" => message} ->
+        {facility, severity} = pri |> String.to_integer() |> divmod(8)
+        %{facility: facility_name(facility), severity: severity_name(severity), message: message}
+
+      _ ->
+        {:error, :not_syslog_format}
+    end
+  end
+
+  defp divmod(numerator, denominator),
+    do: {div(numerator, denominator), Integer.mod(numerator, denominator)}
+
+  defp facility_name(0), do: :kernel
+  defp facility_name(1), do: :user_level
+  defp facility_name(2), do: :mail
+  defp facility_name(3), do: :system
+  defp facility_name(4), do: :security_authorization
+  defp facility_name(5), do: :syslogd
+  defp facility_name(6), do: :line_printer
+  defp facility_name(7), do: :network_news
+  defp facility_name(8), do: :UUCP
+  defp facility_name(9), do: :clock
+  defp facility_name(10), do: :security_authorization
+  defp facility_name(11), do: :FTP
+  defp facility_name(12), do: :NTP
+  defp facility_name(13), do: :log_audit
+  defp facility_name(14), do: :log_alert
+  defp facility_name(15), do: :clock
+  defp facility_name(16), do: :local0
+  defp facility_name(17), do: :local1
+  defp facility_name(18), do: :local2
+  defp facility_name(19), do: :local3
+  defp facility_name(20), do: :local4
+  defp facility_name(21), do: :local5
+  defp facility_name(22), do: :local6
+  defp facility_name(23), do: :local7
+
+  defp severity_name(0), do: :Emergency
+  defp severity_name(1), do: :Alert
+  defp severity_name(2), do: :Critical
+  defp severity_name(3), do: :Error
+  defp severity_name(4), do: :Warning
+  defp severity_name(5), do: :Notice
+  defp severity_name(6), do: :Informational
+  defp severity_name(7), do: :Debug
+
+  defp logger_level(severity) when severity in [:Emergency, :Alert, :Critical, :Error], do: :error
+  defp logger_level(severity) when severity == :Warning, do: :warn
+  defp logger_level(severity) when severity in [:Notice, :Informational], do: :info
+  defp logger_level(severity) when severity == :Debug, do: :debug
+end
+
+defmodule Nerves.Runtime.LogTailer.Syslog do
+  use GenServer
+
+  defdelegate handle_info(message, state), to: Nerves.Runtime.LogTailer
+
+  def start_link() do
+    Nerves.Runtime.LogTailer.start_link(:syslog)
+  end
+end
+
+defmodule Nerves.Runtime.LogTailer.Kmsg do
+  use GenServer
+
+  defdelegate handle_info(message, state), to: Nerves.Runtime.LogTailer
+
+  def start_link() do
+    Nerves.Runtime.LogTailer.start_link(:kmsg)
+  end
+end

--- a/src/log_tailer.c
+++ b/src/log_tailer.c
@@ -1,0 +1,55 @@
+#include <err.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+
+#define KMSG_PATH "/proc/kmsg"
+#define SYSLOG_PATH "/dev/log"
+#define BUFFER_SIZE 1024
+
+static char buffer[BUFFER_SIZE];
+
+int main(int argc, char *argv[]) {
+    if (argc != 2)
+        err(EXIT_FAILURE, "Usage: %s type\n  type must be either syslog or kmsg", argv[0]);
+
+    int fd = 0;
+
+    if (strcasecmp(argv[1], "syslog")) {
+        fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+        if (fd < 0)
+            err(EXIT_FAILURE, "failed to create syslog socket");
+
+        // Erase the old log file (if any) so that we can bind to it
+        unlink(SYSLOG_PATH);
+
+        struct sockaddr_un addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sun_family = AF_UNIX;
+        strcpy(addr.sun_path, SYSLOG_PATH);
+
+        if (bind(fd, (struct sockaddr *) &addr, sizeof(addr)) < 0)
+            err(EXIT_FAILURE, "failed to bind");
+
+        // Make the syslog file writable
+        chmod(SYSLOG_PATH, 0666);
+    } else if (strcasecmp(argv[1], "kmsg")) {
+        fd = open(KMSG_PATH, O_RDONLY);
+        if (fd < 0)
+            err(EXIT_FAILURE, "failed to open");
+    } else {
+        err(EXIT_FAILURE, "Usage: %s type\n  type must be either syslog or kmsg", argv[0]);
+    }
+
+    for (;;) {
+        ssize_t amt = read(fd, buffer, sizeof(buffer));
+        if (amt < 0)
+            err(EXIT_FAILURE, "failed to read");
+
+        write(STDOUT_FILENO, &buffer, amt);
+    }
+}

--- a/test/log_tailer_test.exs
+++ b/test/log_tailer_test.exs
@@ -1,0 +1,52 @@
+defmodule LogTailerTest do
+  use ExUnit.Case
+  doctest Nerves.Runtime.LogTailer
+
+  alias Nerves.Runtime.LogTailer
+
+  describe "parse_syslog_message" do
+    test "parses syslog priority codes" do
+      assert :kernel ==
+        "<0>Test Message"
+        |> LogTailer.parse_syslog_message
+        |> Map.get(:facility)
+
+      assert :Emergency ==
+        "<0>Test Message"
+        |> LogTailer.parse_syslog_message
+        |> Map.get(:severity)
+
+      assert :user_level ==
+        "<13>Test Message"
+        |> LogTailer.parse_syslog_message
+        |> Map.get(:facility)
+
+      assert :Notice ==
+        "<13>Test Message"
+        |> LogTailer.parse_syslog_message
+        |> Map.get(:severity)
+
+      assert :local2 ==
+        "<150>Test Message"
+        |> LogTailer.parse_syslog_message
+        |> Map.get(:facility)
+
+      assert :Informational ==
+        "<150>Test Message"
+        |> LogTailer.parse_syslog_message
+        |> Map.get(:severity)
+    end
+
+    test "returns an error tuple if it can't parse" do
+      assert {:error, :not_syslog_format} == LogTailer.parse_syslog_message("<beef>Test Message")
+    end
+
+    test "parses the message without the syslog priority code" do
+      assert %{message: "[    0.000000] Booting Linux on physical CPU 0x0"} =
+        LogTailer.parse_syslog_message("<6>[    0.000000] Booting Linux on physical CPU 0x0")
+
+      assert %{message: "Jan  1 00:25:42 root: Test Message"} =
+        LogTailer.parse_syslog_message("<13>Jan  1 00:25:42 root: Test Message")
+    end
+  end
+end


### PR DESCRIPTION
I'm interested in feedback from others on this, in particular whether you think it should do less or do the same thing in a different way. For example, I thought it would be useful to parse out the syslog priority so we can pass it to Logger as metadata, which would be useful for filtering.

If you turn on `:all` metadata in `Logger`, it generates kernel messages like this:
```elixir
00:00:09.953 pid=<0.118.0> application=nerves_runtime module=Nerves.Runtime.LogTailer function=handle_message/2 file=/Users/greg/projects/nerves/nerves_runtime/lib/nerves_runtime/log_tailer.ex line=68 type=kmsg facility=kernel severity=Informational timestamp=1970-01-01T00:00:09.834640Z [info]  [    0.000000] Booting Linux on physical CPU 0x0
```

And if you do something like:

```elixir
:os.cmd('echo "test" | logger')
```

then it generates syslog message like this:

```elixir
00:00:50.799 pid=<0.117.0> application=nerves_runtime module=Nerves.Runtime.LogTailer function=handle_message/2 file=/Users/greg/projects/nerves/nerves_runtime/lib/nerves_runtime/log_tailer.ex line=71 type=syslog facility=user_level severity=Notice timestamp=1970-01-01T00:00:50.798929Z [info]  Jan  1 00:00:50 root: test
```