### PR TITLE
Logger updates

### DIFF
--- a/lib/nerves_runtime/application.ex
+++ b/lib/nerves_runtime/application.ex
@@ -14,8 +14,8 @@ defmodule Nerves.Runtime.Application do
     import Supervisor.Spec, warn: false
 
     children = [
-      worker(LogTailer.Syslog, []),
-      worker(LogTailer.Kmsg, []),
+      worker(LogTailer, [:syslog], id: :syslog),
+      worker(LogTailer, [:kmsg], id: :kmsg),
       supervisor(Kernel, []),
       worker(KV, []),
       worker(Init, [])

--- a/lib/nerves_runtime/log_tailer.ex
+++ b/lib/nerves_runtime/log_tailer.ex
@@ -19,9 +19,8 @@ defmodule Nerves.Runtime.LogTailer do
 
   @port_binary_name "log_tailer"
 
-  @doc false
-  def gen_server_name(:syslog), do: __MODULE__.Syslog
-  def gen_server_name(:kmsg), do: __MODULE__.Kmsg
+  defp gen_server_name(:syslog), do: __MODULE__.Syslog
+  defp gen_server_name(:kmsg), do: __MODULE__.Kmsg
 
   @type type :: :syslog | :kmsg
 

--- a/lib/nerves_runtime/log_tailer.ex
+++ b/lib/nerves_runtime/log_tailer.ex
@@ -148,23 +148,3 @@ defmodule Nerves.Runtime.LogTailer do
   defp logger_level(severity) when severity in [:Notice, :Informational], do: :info
   defp logger_level(severity) when severity == :Debug, do: :debug
 end
-
-defmodule Nerves.Runtime.LogTailer.Syslog do
-  use GenServer
-
-  defdelegate handle_info(message, state), to: Nerves.Runtime.LogTailer
-
-  def start_link() do
-    Nerves.Runtime.LogTailer.start_link(:syslog)
-  end
-end
-
-defmodule Nerves.Runtime.LogTailer.Kmsg do
-  use GenServer
-
-  defdelegate handle_info(message, state), to: Nerves.Runtime.LogTailer
-
-  def start_link() do
-    Nerves.Runtime.LogTailer.start_link(:kmsg)
-  end
-end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
+%{
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "system_registry": {:hex, :system_registry, "0.6.0", "31642177e6002d3cff2ada3553ed4e9c0a6ca015797d62d7d17c0ab8696185fc", [:mix], [], "hexpm"}}
+  "ex_doc": {:hex, :ex_doc, "0.18.2", "993e0a95e9fbb790ac54ea58e700b45b299bd48bc44b4ae0404f28161f37a83e", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "system_registry": {:hex, :system_registry, "0.7.0", "cd3aaf2c15392fa60f93869dde49f536fcf60e54f3b15db737e7d4ebcac108f4", [:mix], [], "hexpm"},
+}

--- a/src/erlcmd.c
+++ b/src/erlcmd.c
@@ -94,7 +94,8 @@ static size_t erlcmd_try_dispatch(struct erlcmd *handler)
  */
 void erlcmd_process(struct erlcmd *handler)
 {
-    ssize_t amount_read = read(STDIN_FILENO, handler->buffer + handler->index, sizeof(handler->buffer) - handler->index);
+    ssize_t amount_read = read(STDIN_FILENO, handler->buffer + handler->index,
+                               sizeof(handler->buffer) - handler->index);
     if (amount_read < 0) {
         /* EINTR is ok to get, since we were interrupted by a signal. */
         if (errno == EINTR)

--- a/src/erlcmd.h
+++ b/src/erlcmd.h
@@ -25,8 +25,7 @@
  * Erlang request/response processing
  */
 #define ERLCMD_BUF_SIZE 2048
-struct erlcmd
-{
+struct erlcmd {
     char buffer[ERLCMD_BUF_SIZE];
     size_t index;
 

--- a/src/log_tailer.c
+++ b/src/log_tailer.c
@@ -13,7 +13,8 @@
 
 static char buffer[BUFFER_SIZE];
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
     if (argc != 2)
         err(EXIT_FAILURE, "Usage: %s type\n  type must be either syslog or kmsg", argv[0]);
 

--- a/src/log_tailer.c
+++ b/src/log_tailer.c
@@ -50,6 +50,7 @@ int main(int argc, char *argv[]) {
         if (amt < 0)
             err(EXIT_FAILURE, "failed to read");
 
-        write(STDOUT_FILENO, &buffer, amt);
+        if (write(STDOUT_FILENO, &buffer, amt) < 0)
+            err(EXIT_FAILURE, "write");
     }
 }

--- a/src/uevent.c
+++ b/src/uevent.c
@@ -78,7 +78,7 @@ static void netif_init(struct netif *nb)
         err(EXIT_FAILURE, "mnl_socket_open (NETLINK_KOBJECT_UEVENT)");
 
     // There is one single group in kobject over netlink
-    if (mnl_socket_bind(nb->nl_uevent, (1<<0), MNL_SOCKET_AUTOPID) < 0)
+    if (mnl_socket_bind(nb->nl_uevent, (1 << 0), MNL_SOCKET_AUTOPID) < 0)
         err(EXIT_FAILURE, "mnl_socket_bind");
 
     nb->inet_fd = socket(AF_INET, SOCK_DGRAM, 0);


### PR DESCRIPTION
Various small updates to the logger. It's easiest to look at the individual commits. I think that everything is very minor and uncontroversial with the possible exception of the first commit. The first commit removes the LogTailer.Kmsg and LogTailer.Syslog methods. This was instigated by an Elixir 1.6 warning about the missing init method. 