### PR TITLE
Add dmesg to the helpers; update install message

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The `Nerves.Runtime.Helpers` module provides a number of functions that are
 useful when working at the IEx prompt on a target. They include:
 
 * `cmd/1` - runs a shell command and prints the output
+* `dmesg/0` - dump kernel messages
 * `hex/1` - inspects a value in hexadecimal mode
 * `reboot/0` - reboots gracefully
 * `reboot!/0` - reboots immediately
@@ -214,7 +215,8 @@ useful when working at the IEx prompt on a target. They include:
 More information is available in the module docs for `Nerves.Runtime.Helpers`
 and through `h/1`.
 
-The IEx helpers aren't loaded by default. To use them, run the following:
+Prior to Nerves 1.0.0, the IEx helpers weren't loaded by default in the new
+project generator. To use them, run the following:
 
 ```elixir
 iex> use Nerves.Runtime.Helpers

--- a/lib/nerves_runtime/helpers.ex
+++ b/lib/nerves_runtime/helpers.ex
@@ -64,6 +64,14 @@ defmodule Nerves.Runtime.Helpers do
   end
 
   @doc """
+  Print out kernel log messages
+  """
+  def dmesg() do
+    cmd("dmesg")
+    IEx.dont_display_result()
+  end
+
+  @doc """
   Shortcut to reboot a board. This is a graceful reboot, so it takes some time
   before the real reboot.
   """


### PR DESCRIPTION
Even though the kernel messages are logged, I so often run "dmesg" that
it seemed like a good command to add as a helper.