### PR TITLE
Log commands output into logger

### DIFF
--- a/lib/nerves_runtime.ex
+++ b/lib/nerves_runtime.ex
@@ -1,6 +1,8 @@
 defmodule Nerves.Runtime do
   require Logger
 
+  alias Nerves.Runtime.OutputLogger
+
   @revert_fw_path "/usr/share/fwup/revert.fw"
 
   @moduledoc """
@@ -49,8 +51,8 @@ defmodule Nerves.Runtime do
   Run system command and log output into logger.
   """
   @spec cmd(binary(), [binary()], :debug | :info | :warn | :error | :return) :: {Collectable.t(), exit_status :: non_neg_integer()}
-  defp cmd(cmd, params, :return), do: System.cmd(cmd, params, stderr_to_stdout: true)
-  defp cmd(cmd, params, out), do: System.cmd(cmd, params, into: OutputLogger.new(out), stderr_to_stdout: true)
+  def cmd(cmd, params, :return), do: System.cmd(cmd, params, stderr_to_stdout: true)
+  def cmd(cmd, params, out), do: System.cmd(cmd, params, into: OutputLogger.new(out), stderr_to_stdout: true)
 
   # private helpers
 

--- a/lib/nerves_runtime/output_logger.ex
+++ b/lib/nerves_runtime/output_logger.ex
@@ -2,7 +2,7 @@ defmodule Nerves.Runtime.OutputLogger do
   defstruct [:level]
 
   def new(level) do
-    %OutputLogger{level: level}
+    %__MODULE__{level: level}
   end
 
   defimpl Collectable do

--- a/lib/nerves_runtime/output_logger.ex
+++ b/lib/nerves_runtime/output_logger.ex
@@ -1,0 +1,23 @@
+defmodule Nerves.Runtime.OutputLogger do
+  defstruct [:level]
+
+  def new(level) do
+    %OutputLogger{level: level}
+  end
+
+  defimpl Collectable do
+    def into(%{level: level} = stream) do
+      {:ok, log(stream, level)}
+    end
+
+    def log(stream, level) do
+      fn
+        :ok, {:cont, logs} ->
+          logs
+          |> String.split("\n")
+          |> Enum.each(&Logger.bare_log(level, fn -> &1 end))
+        :ok, _ -> stream
+      end
+    end
+  end
+end


### PR DESCRIPTION
I figured out that some of the commands invoked logs its output directly into linux console.  In the future, I want to have some kind of splash screen, so I will not able to see what was logged there. 

This PR address this issue. Will redirect all commands invoked by `nerves_runtime` output into logger with `:info` level.
