### PR TITLE
Read the uboot env directly if running OTP 21

### DIFF
--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -20,9 +20,27 @@ defmodule Nerves.Runtime.KV do
   using get_active and get_all_active. The result of these
   functions will trim the firmware slot (`"a."` or `"b."`)
   from the leading characters of the keys returned.
+
+  ## Technical Information
+
+  Nerves.Runtime.KV uses a non-replicated U-Boot environment block for storing 
+  firmware and provisioning information. It has the following format:
+
+    * CRC32 of bytes 4 through to the end
+    * `"<key>=<value>\0"` for each key/value pair
+    * `"\0"` an empty key/value pair to terminate the list. 
+      This looks like "\0\0" when you're viewing the file in a hex editor.
+    * Filler bytes to the end of the environment block. These are usually `0xff`.
+
+  The U-Boot environment configuration is loaded from /etc/fw_env.config.
+  If you are using OTP >= 21, the contents of the U-Boot environment will be
+  read directly from the device. This addresses an issue with parsing
+  milti-line values from a call to `fw_printenv`
   """
   use GenServer
   require Logger
+
+  @config "/etc/fw_env.config"
 
   @doc """
   Start the KV store server
@@ -62,9 +80,15 @@ defmodule Nerves.Runtime.KV do
   # GenServer API
 
   def init(_kv) do
-    exec = System.find_executable("fw_printenv")
-    s = load_kv(exec)
-    {:ok, s}
+    with {:ok, config} <- read_config(@config),
+         {dev_name, dev_offset, env_size} <- parse_config(config),
+         {:ok, kv} <- load_kv(dev_name, dev_offset, env_size) do
+      {:ok, kv}
+    else
+      _error ->
+        exec = System.find_executable("fw_printenv")
+        {:ok, load_kv(exec)}
+    end
   end
 
   def handle_call({:get_active, key}, _from, s) do
@@ -98,16 +122,41 @@ defmodule Nerves.Runtime.KV do
     end
   end
 
-  def parse_kv(str) do
-    String.split(str, "\n")
-    |> Enum.map(&String.split(&1, "="))
-    |> Enum.reduce(%{}, fn
-      [k, v], acc ->
-        Map.put(acc, k, v)
+  # OTP 21 FTW
+  # Load the UBoot env from the source
+  defp load_kv(dev_name, dev_offset, env_size) do
+    {:ok, fd} = File.open(dev_name)
+    {:ok, bin} = :file.pread(fd, dev_offset, env_size)
+    File.close(fd)
+    <<expected_crc::little-size(32), tail::binary>> = bin
+    actual_crc = :erlang.crc32(tail)
 
-      _, acc ->
-        acc
-    end)
+    if actual_crc == expected_crc do
+      kv =
+        tail
+        |> :binary.bin_to_list()
+        |> Enum.chunk_by(fn b -> b == 0 end)
+        |> Enum.reject(&(&1 == [0]))
+        |> Enum.take_while(&(&1 != [0, 0]))
+        |> parse_kv()
+
+      {:ok, kv}
+    else
+      {:error, :invalid_crc}
+    end
+  end
+
+  def parse_kv(kv) when is_list(kv) do
+    kv
+    |> Enum.map(&to_string(&1))
+    |> Enum.map(&String.split(&1, "=", parts: 2))
+    |> Enum.map(fn [k, v] -> {k, v} end)
+    |> Enum.into(%{})
+  end
+
+  def parse_kv(kv) when is_binary(kv) do
+    String.split(kv, "\n", trim: true)
+    |> parse_kv()
   end
 
   defp active(s), do: Map.get(s, "nerves_fw_active", "")
@@ -123,4 +172,26 @@ defmodule Nerves.Runtime.KV do
     |> Enum.map(fn {k, v} -> {String.replace_leading(k, active, ""), v} end)
     |> Enum.into(%{})
   end
+
+  defp read_config(file) do
+    case File.read(file) do
+      {:ok, config} -> {:ok, config}
+      _ -> {:error, :no_config}
+    end
+  end
+
+  defp parse_config(config) do
+    [config] =
+      config
+      |> String.split("\n", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&String.starts_with?(&1, "#"))
+
+    [dev_name, dev_offset, env_size | _] = String.split(config, "\t", trim: true)
+
+    {dev_name, parse_int(dev_offset), parse_int(env_size)}
+  end
+
+  defp parse_int(<<"0x", hex_int::binary()>>), do: String.to_integer(hex_int, 16)
+  defp parse_int(decimal_int), do: String.to_integer(decimal_int)
 end

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -35,7 +35,7 @@ defmodule Nerves.Runtime.KV do
   The U-Boot environment configuration is loaded from /etc/fw_env.config.
   If you are using OTP >= 21, the contents of the U-Boot environment will be
   read directly from the device. This addresses an issue with parsing
-  milti-line values from a call to `fw_printenv`
+  multi-line values from a call to `fw_printenv`.
   """
   use GenServer
   require Logger


### PR DESCRIPTION
It is impossible to parse multi line values from the uboot env dump of `fw_printenv`. If running on OTP 21, we can read the UBoot env blocks directly and parse them on the null byte.