### PR TITLE
Fixes issues with parsing fw_env.config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.3
+
+* Bug Fixes
+  * Fix issue with parsing fw_env.config files with space separated values.
+
 ## v0.6.2
 
 * Enhancements

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Nerves.Runtime.MixProject do
   def project do
     [
       app: :nerves_runtime,
-      version: "0.6.2",
+      version: "0.6.3",
       elixir: "~> 1.4",
       start_permanent: Mix.env() == :prod,
       make_clean: ["clean"],

--- a/test/fixtures/fw_env.config
+++ b/test/fixtures/fw_env.config
@@ -1,0 +1,10 @@
+# fw_printenv and fw_setenv configuration
+#
+# This is only used for storing firmware metadata on this platform. Even though
+# the sytsem uses U-Boot, U-Boot is not configured to use this region its environment.
+#
+# See fwup.conf for offset and size
+
+# Device name	Device offset	Env. size	Flash sector size	Number of sectors
+/dev/mmcblk0	0x100000	0x2000		0x200			16
+

--- a/test/fixtures/spaces_fw_env.config
+++ b/test/fixtures/spaces_fw_env.config
@@ -1,0 +1,24 @@
+# Configuration file for fw_(printenv/setenv) utility.
+# Up to two entries are valid, in this case the redundant
+# environment sector is assumed present.
+# Notice, that the "Number of sectors" is not required on NOR and SPI-dataflash.
+# Futhermore, if the Flash sector size is ommitted, this value is assumed to
+# be the same as the Environment size, which is valid for NOR and SPI-dataflash
+
+# NOR example
+# MTD device name    Device offset    Env. size    Flash sector size    Number of sectors
+#/dev/mtd1        0xa0000        0x2000        0x10000
+#/dev/mtd2        0x0000        0x4000        0x4000
+
+# MTD SPI-dataflash example
+# MTD device name    Device offset    Env. size    Flash sector size    Number of sectors
+#/dev/mtd1        0xa0000        0x2000
+/dev/mtd3        0x0        0x1000   0x10000
+
+#/dev/mtd6        0x4200        0x4200
+
+# NAND example
+#/dev/mtd0        0x4000        0x4000        0x20000            2
+
+# Block device example
+#/dev/mmcblk0        0xc0000        0x20000

--- a/test/kv_test.exs
+++ b/test/kv_test.exs
@@ -2,6 +2,8 @@ defmodule KVTest do
   use ExUnit.Case
   doctest Nerves.Runtime.KV
 
+  @fixtures Path.expand("fixtures", __DIR__)
+
   alias Nerves.Runtime.KV
 
   test "parse kv" do
@@ -34,5 +36,21 @@ defmodule KVTest do
     }
 
     assert KV.parse_kv(kv_raw) == kv
+  end
+
+  test "can parse fw_env.config for common systems" do
+    {:ok, config} =
+      Path.join(@fixtures, "fw_env.config")
+      |> KV.read_config()
+
+    assert {"/dev/mmcblk0", 0x100000, 0x2000} = KV.parse_config(config)
+  end
+
+  test "can parse fw_env.config with spaces" do
+    {:ok, config} =
+      Path.join(@fixtures, "spaces_fw_env.config")
+      |> KV.read_config()
+
+    assert {"/dev/mtd3", 0x0, 0x1000} = KV.parse_config(config)
   end
 end


### PR DESCRIPTION
@michaelkschmidt reported an issue with parsing fw_env.config files that contain spaces instead of tabs and illustrated issues with determining fw_env loading behavior depending on OTP version.

This PR fixes the parsing, adds tests, and makes `File.open` safe for < OTP 21 systems