### PR TITLE
Mock modules when MIX_TARGET = host

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,6 @@
 use Mix.Config
 
 config :nerves_runtime, :enable_syslog, Mix.env() != :test
+
+config :nerves_runtime,
+  target: "host"

--- a/lib/nerves_runtime.ex
+++ b/lib/nerves_runtime.ex
@@ -72,6 +72,11 @@ defmodule Nerves.Runtime do
   def cmd(cmd, params, out),
     do: System.cmd(cmd, params, into: OutputLogger.new(out), stderr_to_stdout: true)
 
+  def target() do
+    target = Application.get_env(:nerves_runtime, :target)
+    if target == "host", do: "host", else: "target"
+  end
+
   # private helpers
 
   defp logged_shutdown(cmd) do

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -20,22 +20,6 @@ defmodule Nerves.Runtime.KV do
   using get_active and get_all_active. The result of these
   functions will trim the firmware slot (`"a."` or `"b."`)
   from the leading characters of the keys returned.
-
-  ## Technical Information
-
-  Nerves.Runtime.KV uses a non-replicated U-Boot environment block for storing
-  firmware and provisioning information. It has the following format:
-
-    * CRC32 of bytes 4 through to the end
-    * `"<key>=<value>\0"` for each key/value pair
-    * `"\0"` an empty key/value pair to terminate the list.
-      This looks like "\0\0" when you're viewing the file in a hex editor.
-    * Filler bytes to the end of the environment block. These are usually `0xff`.
-
-  The U-Boot environment configuration is loaded from /etc/fw_env.config.
-  If you are using OTP >= 21, the contents of the U-Boot environment will be
-  read directly from the device. This addresses an issue with parsing
-  multi-line values from a call to `fw_printenv`.
   """
 
   use GenServer

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -37,16 +37,28 @@ defmodule Nerves.Runtime.KV do
   read directly from the device. This addresses an issue with parsing
   multi-line values from a call to `fw_printenv`.
   """
+
   use GenServer
   require Logger
 
-  @config "/etc/fw_env.config"
+  @callback init(opts :: any) :: inital_state :: map
+
+  alias __MODULE__
+
+  mod =
+    if Nerves.Runtime.target() != "host" do
+      KV.UBootEnv
+    else
+      KV.Mock
+    end
+
+  @default_mod mod
 
   @doc """
   Start the KV store server
   """
-  def start_link(kv \\ "") do
-    GenServer.start_link(__MODULE__, kv, name: __MODULE__)
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
   @doc """
@@ -77,18 +89,15 @@ defmodule Nerves.Runtime.KV do
     GenServer.call(__MODULE__, :get_all)
   end
 
-  # GenServer API
+  @doc """
+  Get the key regardless of firmware slot
+  """
+  def put(key, value) do
+    mod().put(key, value)
+  end
 
-  def init(_kv) do
-    with {:ok, config} <- read_config(@config),
-         {dev_name, dev_offset, env_size} <- parse_config(config),
-         {:ok, kv} <- load_kv(dev_name, dev_offset, env_size) do
-      {:ok, kv}
-    else
-      _error ->
-        exec = System.find_executable("fw_printenv")
-        {:ok, load_kv(exec)}
-    end
+  def init(opts) do
+    {:ok, mod().init(opts)}
   end
 
   def handle_call({:get_active, key}, _from, s) do
@@ -109,80 +118,6 @@ defmodule Nerves.Runtime.KV do
     {:reply, s, s}
   end
 
-  def read_config(file) do
-    case File.read(file) do
-      {:ok, config} -> {:ok, config}
-      _ -> {:error, :no_config}
-    end
-  end
-
-  def parse_config(config) do
-    [config] =
-      config
-      |> String.split("\n", trim: true)
-      |> Enum.map(&String.trim/1)
-      |> Enum.reject(&String.starts_with?(&1, "#"))
-
-    [dev_name, dev_offset, env_size | _] = String.split(config) |> Enum.map(&String.trim/1)
-
-    {dev_name, parse_int(dev_offset), parse_int(env_size)}
-  end
-
-  def parse_kv(kv) when is_list(kv) do
-    kv
-    |> Enum.map(&to_string(&1))
-    |> Enum.map(&String.split(&1, "=", parts: 2))
-    |> Enum.map(fn [k, v] -> {k, v} end)
-    |> Enum.into(%{})
-  end
-
-  def parse_kv(kv) when is_binary(kv) do
-    String.split(kv, "\n", trim: true)
-    |> parse_kv()
-  end
-
-  defp load_kv(nil), do: %{}
-
-  defp load_kv(exec) do
-    case System.cmd(exec, []) do
-      {result, 0} ->
-        parse_kv(result)
-
-      {result, code} ->
-        Logger.warn("#{inspect(__MODULE__)} failed to load fw env (#{code}): #{result}")
-        %{}
-    end
-  end
-
-  # OTP 21 FTW
-  # Load the UBoot env from the source
-  def load_kv(dev_name, dev_offset, env_size) do
-    case File.open(dev_name) do
-      {:ok, fd} ->
-        {:ok, bin} = :file.pread(fd, dev_offset, env_size)
-        File.close(fd)
-        <<expected_crc::little-size(32), tail::binary>> = bin
-        actual_crc = :erlang.crc32(tail)
-
-        if actual_crc == expected_crc do
-          kv =
-            tail
-            |> :binary.bin_to_list()
-            |> Enum.chunk_by(fn b -> b == 0 end)
-            |> Enum.reject(&(&1 == [0]))
-            |> Enum.take_while(&(hd(&1) != 0))
-            |> parse_kv()
-
-          {:ok, kv}
-        else
-          {:error, :invalid_crc}
-        end
-
-      error ->
-        error
-    end
-  end
-
   defp active(s), do: Map.get(s, "nerves_fw_active", "")
 
   defp active(key, s) do
@@ -197,6 +132,7 @@ defmodule Nerves.Runtime.KV do
     |> Enum.into(%{})
   end
 
-  defp parse_int(<<"0x", hex_int::binary()>>), do: String.to_integer(hex_int, 16)
-  defp parse_int(decimal_int), do: String.to_integer(decimal_int)
+  defp mod() do
+    Application.get_env(:nerves_runtime, :modules)[__MODULE__] || @default_mod
+  end
 end

--- a/lib/nerves_runtime/kv/mock.ex
+++ b/lib/nerves_runtime/kv/mock.ex
@@ -1,0 +1,10 @@
+defmodule Nerves.Runtime.KV.Mock do
+  @behaviour Nerves.Runtime.KV
+
+  def init(state) do
+    Application.get_env(:nerves_runtime, __MODULE__) || init_state(state)
+  end
+
+  def init_state(state) when is_map(state), do: state
+  def init_state(_state), do: %{}
+end

--- a/lib/nerves_runtime/kv/uboot_env.ex
+++ b/lib/nerves_runtime/kv/uboot_env.ex
@@ -1,4 +1,22 @@
 defmodule Nerves.Runtime.KV.UBootEnv do
+  @moduledoc """
+  ## Technical Information
+
+  Nerves.Runtime.KV.UBootEnv uses a non-replicated U-Boot environment block for
+  storing firmware and provisioning information. It has the following format:
+
+    * CRC32 of bytes 4 through to the end
+    * `"<key>=<value>\0"` for each key/value pair
+    * `"\0"` an empty key/value pair to terminate the list.
+      This looks like "\0\0" when you're viewing the file in a hex editor.
+    * Filler bytes to the end of the environment block. These are usually `0xff`.
+
+  The U-Boot environment configuration is loaded from /etc/fw_env.config.
+  If you are using OTP >= 21, the contents of the U-Boot environment will be
+  read directly from the device. This addresses an issue with parsing
+  multi-line values from a call to `fw_printenv`.
+  """
+
   require Logger
 
   @behaviour Nerves.Runtime.KV

--- a/lib/nerves_runtime/kv/uboot_env.ex
+++ b/lib/nerves_runtime/kv/uboot_env.ex
@@ -1,0 +1,98 @@
+defmodule Nerves.Runtime.KV.UBootEnv do
+  require Logger
+
+  @behaviour Nerves.Runtime.KV
+
+  @config "/etc/fw_env.config"
+
+  # Nerves.Runtime.KV behaviour
+
+  def init(_opts) do
+    with {:ok, config} <- read_config(@config),
+         {dev_name, dev_offset, env_size} <- parse_config(config),
+         {:ok, kv} <- load_kv(dev_name, dev_offset, env_size) do
+      kv
+    else
+      _error ->
+        exec = System.find_executable("fw_printenv")
+        load_kv(exec)
+    end
+  end
+
+  def read_config(file) do
+    case File.read(file) do
+      {:ok, config} -> {:ok, config}
+      _ -> {:error, :no_config}
+    end
+  end
+
+  def parse_config(config) do
+    [config] =
+      config
+      |> String.split("\n", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&String.starts_with?(&1, "#"))
+
+    [dev_name, dev_offset, env_size | _] = String.split(config) |> Enum.map(&String.trim/1)
+
+    {dev_name, parse_int(dev_offset), parse_int(env_size)}
+  end
+
+  def parse_kv(kv) when is_list(kv) do
+    kv
+    |> Enum.map(&to_string(&1))
+    |> Enum.map(&String.split(&1, "=", parts: 2))
+    |> Enum.map(fn [k, v] -> {k, v} end)
+    |> Enum.into(%{})
+  end
+
+  def parse_kv(kv) when is_binary(kv) do
+    String.split(kv, "\n", trim: true)
+    |> parse_kv()
+  end
+
+  defp load_kv(nil), do: %{}
+
+  defp load_kv(exec) do
+    case System.cmd(exec, []) do
+      {result, 0} ->
+        parse_kv(result)
+
+      {result, code} ->
+        Logger.warn("#{inspect(__MODULE__)} failed to load fw env (#{code}): #{result}")
+        %{}
+    end
+  end
+
+  # OTP 21 FTW
+  # Load the UBoot env from the source
+  def load_kv(dev_name, dev_offset, env_size) do
+    case File.open(dev_name) do
+      {:ok, fd} ->
+        {:ok, bin} = :file.pread(fd, dev_offset, env_size)
+        File.close(fd)
+        <<expected_crc::little-size(32), tail::binary>> = bin
+        actual_crc = :erlang.crc32(tail)
+
+        if actual_crc == expected_crc do
+          kv =
+            tail
+            |> :binary.bin_to_list()
+            |> Enum.chunk_by(fn b -> b == 0 end)
+            |> Enum.reject(&(&1 == [0]))
+            |> Enum.take_while(&(hd(&1) != 0))
+            |> parse_kv()
+
+          {:ok, kv}
+        else
+          {:error, :invalid_crc}
+        end
+
+      error ->
+        error
+    end
+  end
+
+  defp parse_int(<<"0x", hex_int::binary()>>), do: String.to_integer(hex_int, 16)
+  defp parse_int(decimal_int), do: String.to_integer(decimal_int)
+end

--- a/test/kv/uboot_env_test.exs
+++ b/test/kv/uboot_env_test.exs
@@ -1,0 +1,78 @@
+defmodule Nerves.Runtime.KV.UBootEnvTest do
+  use ExUnit.Case
+  doctest Nerves.Runtime.KV.UBootEnv
+
+  @fixtures Path.expand("../fixtures", __DIR__)
+
+  alias Nerves.Runtime.KV.UBootEnv
+
+  test "parse kv" do
+    kv_raw = """
+    a.nerves_fw_application_part0_devpath=/dev/mmcblk0p3
+    a.nerves_fw_application_part0_fstype=ext4
+    a.nerves_fw_application_part0_target=/root
+    a.nerves_fw_architecture=arm
+    a.nerves_fw_author=The Nerves Team
+    a.nerves_fw_description=
+    a.nerves_fw_platform=rpi
+    a.nerves_fw_product=Nerves Firmware
+    a.nerves_fw_version=
+    nerves_fw_active=a
+    nerves_fw_devpath=/dev/mmcblk0
+    """
+
+    kv = %{
+      "a.nerves_fw_application_part0_devpath" => "/dev/mmcblk0p3",
+      "a.nerves_fw_application_part0_fstype" => "ext4",
+      "a.nerves_fw_application_part0_target" => "/root",
+      "a.nerves_fw_architecture" => "arm",
+      "a.nerves_fw_author" => "The Nerves Team",
+      "a.nerves_fw_description" => "",
+      "a.nerves_fw_platform" => "rpi",
+      "a.nerves_fw_product" => "Nerves Firmware",
+      "a.nerves_fw_version" => "",
+      "nerves_fw_active" => "a",
+      "nerves_fw_devpath" => "/dev/mmcblk0"
+    }
+
+    assert UBootEnv.parse_kv(kv_raw) == kv
+  end
+
+  test "can parse fw_env.config for common systems" do
+    {:ok, config} =
+      Path.join(@fixtures, "fw_env.config")
+      |> UBootEnv.read_config()
+
+    assert {"/dev/mmcblk0", 0x100000, 0x2000} = UBootEnv.parse_config(config)
+  end
+
+  test "can parse fw_env.config with spaces" do
+    {:ok, config} =
+      Path.join(@fixtures, "spaces_fw_env.config")
+      |> UBootEnv.read_config()
+
+    assert {"/dev/mtd3", 0x0, 0x1000} = UBootEnv.parse_config(config)
+  end
+
+  test "can parse u-boot tools created environment" do
+    dev_name = Path.join(@fixtures, "fixture_uboot.bin")
+    dev_offset = 0x1000
+    env_size = 0x2000
+
+    {:ok, kv} = UBootEnv.load_kv(dev_name, dev_offset, env_size)
+
+    assert Map.get(kv, "serial_number") == "12345"
+    assert Map.get(kv, "a.nerves_fw_application_part0_devpath") == "/dev/mmcblk0p4"
+  end
+
+  test "can parse fwup-created environment" do
+    dev_name = Path.join(@fixtures, "fixture_fwup.bin")
+    dev_offset = 0x1000
+    env_size = 0x2000
+
+    {:ok, kv} = UBootEnv.load_kv(dev_name, dev_offset, env_size)
+
+    assert Map.get(kv, "serial_number") == "112233"
+    assert Map.get(kv, "a.nerves_fw_application_part0_devpath") == "/dev/mmcblk0p4"
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+Logger.configure(level: :error)
+
 ExUnit.start()


### PR DESCRIPTION
This PR disables most of the main supervisor children in `Nerves.Runtime` and allows the `Nerves.Runtime.KV` to be mocked with data by providing an application config.

```
# config/config.exs
config :nerves_runtime, :modules, [
  {Nerves.Runtime.KV.Mock, %{"key" => "value"}}
]
```