### PR TITLE
Add put/2 for writing to uboot-env and refactor

### DIFF
--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -73,13 +73,6 @@ defmodule Nerves.Runtime.KV do
     GenServer.call(__MODULE__, :get_all)
   end
 
-  @doc """
-  Get the key regardless of firmware slot
-  """
-  def put(key, value) do
-    mod().put(key, value)
-  end
-
   def init(opts) do
     {:ok, mod().init(opts)}
   end

--- a/lib/nerves_runtime/kv/uboot_env.ex
+++ b/lib/nerves_runtime/kv/uboot_env.ex
@@ -17,139 +17,26 @@ defmodule Nerves.Runtime.KV.UBootEnv do
   multi-line values from a call to `fw_printenv`.
   """
 
-  require Logger
-
   @behaviour Nerves.Runtime.KV
 
-  @config "/etc/fw_env.config"
+  alias Nerves.Runtime.UBootEnv
 
   def init(_opts) do
-    read()
+    case UBootEnv.read() do
+      {:ok, kv} -> kv
+      _error -> %{}
+    end
   end
 
   def put(key, value) do
-    read()
-    |> Map.put(key, value)
-    |> write()
-  end
-
-  def read_config(file) do
-    case File.read(file) do
-      {:ok, config} -> {:ok, config}
-      _ -> {:error, :no_config}
-    end
-  end
-
-  def parse_config(config) do
-    [config] =
-      config
-      |> String.split("\n", trim: true)
-      |> Enum.map(&String.trim/1)
-      |> Enum.reject(&String.starts_with?(&1, "#"))
-
-    [dev_name, dev_offset, env_size | _] = String.split(config) |> Enum.map(&String.trim/1)
-
-    {dev_name, parse_int(dev_offset), parse_int(env_size)}
-  end
-
-  def decode(kv) when is_list(kv) do
-    kv
-    |> Enum.map(&to_string(&1))
-    |> Enum.map(&String.split(&1, "=", parts: 2))
-    |> Enum.map(fn [k, v] -> {k, v} end)
-    |> Enum.into(%{})
-  end
-
-  def decode(kv) when is_binary(kv) do
-    String.split(kv, "\n", trim: true)
-    |> decode()
-  end
-
-  def encode(kv, env_size) when is_map(kv) do
-    kv =
-      kv
-      |> Enum.map(&(elem(&1, 0) <> "=" <> elem(&1, 1)))
-      |> Enum.join(<<0>>)
-
-    kv = kv <> <<0, 0>>
-    padding = env_size - byte_size(kv) - 4
-    padding = <<-1::signed-unit(8)-size(padding)>>
-    crc = :erlang.crc32(kv <> padding)
-    crc = <<crc::little-size(32)>>
-    crc <> kv <> padding
-  end
-
-  def read() do
-    with {:ok, config} <- read_config(@config),
-         {dev_name, dev_offset, env_size} <- parse_config(config),
-         {:ok, kv} <- load(dev_name, dev_offset, env_size) do
-      kv
-    else
-      _error ->
-        exec = System.find_executable("fw_printenv")
-        load(exec)
-    end
-  end
-
-  def write(kv) do
-    with {:ok, config} <- read_config(@config),
-         {dev_name, dev_offset, env_size} <- parse_config(config),
-         {:ok, fd} <- File.open(dev_name, [:raw, :binary, :write]) do
-      uboot_env = encode(kv, env_size)
-      :ok = :file.pwrite(fd, dev_offset, uboot_env)
-      File.close(fd)
-    else
-      _error ->
-        exec = System.find_executable("fw_setenv")
-
-        Enum.each(kv, fn {k, v} ->
-          System.cmd(exec, [k, v])
-        end)
-    end
-  end
-
-  def load(nil), do: %{}
-
-  def load(exec) do
-    case System.cmd(exec, []) do
-      {result, 0} ->
-        decode(result)
-
-      {result, code} ->
-        Logger.warn("#{inspect(__MODULE__)} failed to load fw env (#{code}): #{result}")
-        %{}
-    end
-  end
-
-  # OTP 21 FTW
-  # Load the UBoot env from the source
-  def load(dev_name, dev_offset, env_size) do
-    case File.open(dev_name) do
-      {:ok, fd} ->
-        {:ok, bin} = :file.pread(fd, dev_offset, env_size)
-        File.close(fd)
-        <<expected_crc::little-size(32), tail::binary>> = bin
-        actual_crc = :erlang.crc32(tail)
-
-        if actual_crc == expected_crc do
-          kv =
-            tail
-            |> :binary.bin_to_list()
-            |> Enum.chunk_by(fn b -> b == 0 end)
-            |> Enum.reject(&(&1 == [0]))
-            |> Enum.take_while(&(hd(&1) != 0))
-            |> decode()
-
-          {:ok, kv}
-        else
-          {:error, :invalid_crc}
-        end
+    case UBootEnv.read() do
+      {:ok, kv} ->
+        kv
+        |> Map.put(key, value)
+        |> UBootEnv.write()
 
       error ->
         error
     end
   end
-
-  defp parse_int(<<"0x", hex_int::binary()>>), do: String.to_integer(hex_int, 16)
-  defp parse_int(decimal_int), do: String.to_integer(decimal_int)
 end

--- a/lib/nerves_runtime/uboot_env.ex
+++ b/lib/nerves_runtime/uboot_env.ex
@@ -1,0 +1,93 @@
+defmodule Nerves.Runtime.UBootEnv do
+  alias Nerves.Runtime.UBootEnv.{Config, Tools}
+
+  @doc """
+  Read the UBoot environment into a map or key value pairs
+  """
+  @spec read() ::
+          {:ok, map}
+          | {:error, reason :: binary}
+  def read() do
+    with {:ok, {dev_name, dev_offset, env_size}} <- Config.read(),
+         {:ok, kv} <- load(dev_name, dev_offset, env_size) do
+      {:ok, kv}
+    else
+      _error ->
+        Tools.fw_printenv()
+    end
+  end
+
+  @doc """
+  Write a map of key value pairs to the UBoot environment
+  """
+  @spec write(kv :: map) :: :ok | {:error, reason :: any}
+  def write(kv) do
+    with {:ok, {dev_name, dev_offset, env_size}} <- Config.read(),
+         {:ok, fd} <- File.open(dev_name, [:raw, :binary, :write]) do
+      uboot_env = encode(kv, env_size)
+      :ok = :file.pwrite(fd, dev_offset, uboot_env)
+      File.close(fd)
+    else
+      _error ->
+        Enum.each(kv, fn {key, value} ->
+          Tools.fw_setenv(key, value)
+        end)
+    end
+  end
+
+  @doc """
+  Decode a list of key value pairs into a map
+  """
+  def decode(env) when is_list(env) do
+    env
+    |> Enum.map(&to_string(&1))
+    |> Enum.map(&String.split(&1, "=", parts: 2))
+    |> Enum.map(fn [k, v] -> {k, v} end)
+    |> Enum.into(%{})
+  end
+
+  @doc """
+  Encode a list of key value pairs into the binary form of the UBoot Env
+  """
+  def encode(kv, env_size) when is_map(kv) do
+    kv =
+      kv
+      |> Enum.map(&(elem(&1, 0) <> "=" <> elem(&1, 1)))
+      |> Enum.join(<<0>>)
+
+    kv = kv <> <<0, 0>>
+    padding = env_size - byte_size(kv) - 4
+    padding = <<-1::signed-unit(8)-size(padding)>>
+    crc = :erlang.crc32(kv <> padding)
+    crc = <<crc::little-size(32)>>
+    crc <> kv <> padding
+  end
+
+  # Requires OTP >= 21
+  def load(dev_name, dev_offset, env_size) do
+    case File.open(dev_name) do
+      {:ok, fd} ->
+        {:ok, bin} = :file.pread(fd, dev_offset, env_size)
+        File.close(fd)
+        <<expected_crc::little-size(32), tail::binary>> = bin
+        actual_crc = :erlang.crc32(tail)
+
+        if actual_crc == expected_crc do
+          kv =
+            tail
+            |> :binary.bin_to_list()
+            |> Enum.chunk_by(fn b -> b == 0 end)
+            |> Enum.reject(&(&1 == [0]))
+            |> Enum.take_while(&(hd(&1) != 0))
+            |> decode()
+
+          {:ok, kv}
+        else
+          {:error, :invalid_crc}
+        end
+
+      error ->
+        error
+    end
+  end
+end

--- a/lib/nerves_runtime/uboot_env/config.ex
+++ b/lib/nerves_runtime/uboot_env/config.ex
@@ -1,0 +1,30 @@
+defmodule Nerves.Runtime.UBootEnv.Config do
+  @default_config_file "/etc/fw_env.config"
+
+  @spec read(file :: binary) ::
+          {:ok, {dev_name :: binary, dev_offset :: non_neg_integer, env_size :: non_neg_integer}}
+          | {:error, reason :: any}
+  def read(config_file \\ nil) do
+    config_file = config_file || @default_config_file
+
+    case File.read(config_file) do
+      {:ok, config} -> {:ok, decode(config)}
+      _error -> {:error, :no_config}
+    end
+  end
+
+  def decode(config) do
+    [config] =
+      config
+      |> String.split("\n", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&String.starts_with?(&1, "#"))
+
+    [dev_name, dev_offset, env_size | _] = String.split(config) |> Enum.map(&String.trim/1)
+
+    {dev_name, parse_int(dev_offset), parse_int(env_size)}
+  end
+
+  defp parse_int(<<"0x", hex_int::binary()>>), do: String.to_integer(hex_int, 16)
+  defp parse_int(decimal_int), do: String.to_integer(decimal_int)
+end

--- a/lib/nerves_runtime/uboot_env/tools.ex
+++ b/lib/nerves_runtime/uboot_env/tools.ex
@@ -1,0 +1,42 @@
+defmodule Nerves.Runtime.UBootEnv.Tools do
+  alias Nerves.Runtime.UBootEnv
+
+  @spec fw_setenv(key :: binary, value :: binary) ::
+          {:ok, env :: [binary]}
+          | {:error, reason :: binary}
+  def fw_printenv do
+    case exec("fw_printenv") do
+      {:ok, env} -> {:ok, decode(env)}
+      error -> error
+    end
+  end
+
+  @spec fw_setenv(key :: binary, value :: binary) ::
+          :ok
+          | {:error, reason :: binary}
+  def fw_setenv(key, value) do
+    case exec("fw_printenv", [key, value]) do
+      {:ok, _} -> :ok
+      error -> error
+    end
+  end
+
+  def decode(env) when is_binary(env) do
+    String.split(env, "\n", trim: true)
+    |> UBootEnv.decode()
+  end
+
+  defp exec(cmd, args \\ []) do
+    if exec = System.find_executable(cmd) do
+      case System.cmd(exec, args) do
+        {result, 0} ->
+          {:ok, String.trim(result)}
+
+        {result, _code} ->
+          {:error, result}
+      end
+    else
+      {:error, cmd <> " not found"}
+    end
+  end
+end

--- a/test/kv/uboot_env_test.exs
+++ b/test/kv/uboot_env_test.exs
@@ -35,7 +35,7 @@ defmodule Nerves.Runtime.KV.UBootEnvTest do
       "nerves_fw_devpath" => "/dev/mmcblk0"
     }
 
-    assert UBootEnv.parse_kv(kv_raw) == kv
+    assert UBootEnv.decode(kv_raw) == kv
   end
 
   test "can parse fw_env.config for common systems" do
@@ -59,7 +59,7 @@ defmodule Nerves.Runtime.KV.UBootEnvTest do
     dev_offset = 0x1000
     env_size = 0x2000
 
-    {:ok, kv} = UBootEnv.load_kv(dev_name, dev_offset, env_size)
+    {:ok, kv} = UBootEnv.load(dev_name, dev_offset, env_size)
 
     assert Map.get(kv, "nerves_serial_number") == "12345"
     assert Map.get(kv, "a.nerves_fw_application_part0_devpath") == "/dev/mmcblk0p4"
@@ -70,9 +70,22 @@ defmodule Nerves.Runtime.KV.UBootEnvTest do
     dev_offset = 0x1000
     env_size = 0x2000
 
-    {:ok, kv} = UBootEnv.load_kv(dev_name, dev_offset, env_size)
+    {:ok, kv} = UBootEnv.load(dev_name, dev_offset, env_size)
 
     assert Map.get(kv, "nerves_serial_number") == "112233"
     assert Map.get(kv, "a.nerves_fw_application_part0_devpath") == "/dev/mmcblk0p4"
+  end
+
+  test "can encode environment" do
+    dev_name = Path.join(@fixtures, "fixture_fwup.bin")
+    dev_offset = 0x1000
+    env_size = 0x2000
+
+    {:ok, kv} = UBootEnv.load(dev_name, dev_offset, env_size)
+    {:ok, fd} = File.open(dev_name)
+
+    {:ok, bin} = :file.pread(fd, dev_offset, env_size)
+    encoded = UBootEnv.encode(kv, env_size)
+    assert bin == encoded
   end
 end

--- a/test/uboot_env_test.exs
+++ b/test/uboot_env_test.exs
@@ -1,10 +1,11 @@
-defmodule Nerves.Runtime.KV.UBootEnvTest do
+defmodule Nerves.Runtime.UBootEnvTest do
   use ExUnit.Case
+  doctest Nerves.Runtime.UBootEnv
   doctest Nerves.Runtime.KV.UBootEnv
 
-  @fixtures Path.expand("../fixtures", __DIR__)
+  @fixtures Path.expand("fixtures", __DIR__)
 
-  alias Nerves.Runtime.KV.UBootEnv
+  alias Nerves.Runtime.UBootEnv
 
   test "parse kv" do
     kv_raw = """
@@ -35,23 +36,23 @@ defmodule Nerves.Runtime.KV.UBootEnvTest do
       "nerves_fw_devpath" => "/dev/mmcblk0"
     }
 
-    assert UBootEnv.decode(kv_raw) == kv
+    assert UBootEnv.Tools.decode(kv_raw) == kv
   end
 
   test "can parse fw_env.config for common systems" do
     {:ok, config} =
       Path.join(@fixtures, "fw_env.config")
-      |> UBootEnv.read_config()
+      |> UBootEnv.Config.read()
 
-    assert {"/dev/mmcblk0", 0x100000, 0x2000} = UBootEnv.parse_config(config)
+    assert {"/dev/mmcblk0", 0x100000, 0x2000} == config
   end
 
   test "can parse fw_env.config with spaces" do
     {:ok, config} =
       Path.join(@fixtures, "spaces_fw_env.config")
-      |> UBootEnv.read_config()
+      |> UBootEnv.Config.read()
 
-    assert {"/dev/mtd3", 0x0, 0x1000} = UBootEnv.parse_config(config)
+    assert {"/dev/mtd3", 0x0, 0x1000} == config
   end
 
   test "can parse u-boot tools created environment" do


### PR DESCRIPTION
This adds the ability to write to the uboot env from elixir. If you are on OTP 21, it will write directly to the uboot env or fall back to calling `fw_setenv` on the command line.