### PR TITLE
Remove dialyxir from test deps

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Nerves.Runtime.MixProject do
       {:system_registry, "~> 0.5"},
       {:elixir_make, "~> 0.4", runtime: false},
       {:ex_doc, "~> 0.18", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev, :test], runtime: false}
+      {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false}
     ]
   end
 


### PR DESCRIPTION
I got an unexpected error when running `mix test` that was due to `dialyxir`. I didn't track it down and it's not happening now. I didn't think that `dialyxir` was needed for test, though, so this removes it.