### PR TITLE
Send uevents on directory traversal

### DIFF
--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -30,6 +30,8 @@ defmodule Nerves.Runtime.Kernel.UEvent do
   end
 
   def handle_info(:discover, s) do
+    # Trigger uevent messages to be sent for all devices that have been enumerated
+    # by the Linux kernel before this GenServer started.
     Device.discover()
     {:noreply, s}
   end


### PR DESCRIPTION
This removes a decent amount of data structure operations and triggers
uevents as the files are found. This causes the add notifications to
occur sooner and this has the side-effect of bringing up networking more
quickly on boot.