### PR TITLE
Move Nerves.Runtime.Helpers to toolshed project

### DIFF
--- a/lib/nerves_runtime/helpers.ex
+++ b/lib/nerves_runtime/helpers.ex
@@ -1,104 +1,11 @@
 defmodule Nerves.Runtime.Helpers do
-  # This is the path on all official Nerves systems
-  @iex_exs_path "/root/.iex.exs"
-
-  @moduledoc """
-  Helper functions for making the IEx prompt a little friendlier to use with
-  Nerves. It is intended to be imported to minimize typing:
-
-      iex> use Nerves.Runtime.Helpers
-
-  For development, you may want to run
-
-      iex> Nerves.Runtime.Helpers.install
-
-  on the target so that the helpers get automatically imported on each boot.
-
-  Helpers include:
-
-   * `cmd/1`     - runs a shell command and prints the output
-   * `hex/1`     - inspects a value with integers printed as hex
-   * `reboot/0`  - reboots gracefully
-   * `reboot!/0` - reboots immediately
-
-  Help for all of these can be found by running:
-
-      iex> h(Nerves.Runtime.Helpers.cmd/1)
-
-  """
+  @moduledoc false
 
   defmacro __using__(_) do
     quote do
-      import Nerves.Runtime.Helpers, except: [install: 0]
-      IO.puts("Nerves.Runtime.Helpers imported. Run h(Nerves.Runtime.Helpers) for more info")
+      IO.puts(
+        "The Nerves.Runtime.Helpers have been removed. Use https://hex.pm/packages/toolshed instead."
+      )
     end
-  end
-
-  @doc """
-  Install the helpers so that they're autoloaded on subsequent reboots.
-  """
-  @spec install() :: :ok
-  def install() do
-    case File.exists?(@iex_exs_path) do
-      false ->
-        File.write!(@iex_exs_path, "use Nerves.Runtime.Helpers")
-        IO.puts("Helpers installed and will be loaded on next reboot. To use")
-        IO.puts("them now, run `use Nerves.Runtime.Helpers`")
-
-      true ->
-        IO.puts("#{@iex_exs_path} already exists.")
-        IO.puts("Please manually add 'use Nerves.Runtime.Helpers' if it's not already there.")
-    end
-  end
-
-  @doc """
-  Run a command and return the exit code. This function is intended to be run
-  interactively.
-  """
-  @spec cmd(String.t() | charlist()) :: integer()
-  def cmd(str) when is_binary(str) do
-    {_collectable, exit_code} = System.cmd("sh", ["-c", str], into: IO.stream(:stdio, :line))
-    exit_code
-  end
-
-  def cmd(str) when is_list(str) do
-    str |> to_string |> cmd
-  end
-
-  @doc """
-  Print out kernel log messages
-  """
-  def dmesg() do
-    cmd("dmesg")
-    IEx.dont_display_result()
-  end
-
-  @doc """
-  Shortcut to reboot a board. This is a graceful reboot, so it takes some time
-  before the real reboot.
-  """
-  @spec reboot() :: no_return()
-  defdelegate reboot(), to: Nerves.Runtime
-
-  @doc """
-  Remote immediately without a graceful shutdown. This is for the impatient.
-  """
-  @spec reboot!() :: no_return()
-  def reboot!() do
-    :erlang.halt()
-  end
-
-  @doc """
-  Inspect a value with all integers printed out in hex. This is useful for
-  one-off hex conversions. If you're doing a lot of work that requires
-  hexadecimal output, you should consider running:
-
-  `IEx.configure(inspect: [base: :hex])`
-
-  The drawback of doing the above is that strings print out as hex binaries.
-  """
-  @spec hex(integer()) :: String.t()
-  def hex(value) do
-    inspect(value, base: :hex)
   end
 end


### PR DESCRIPTION
Since `nerves_runtime` is a required dependency for all Nerves projects,
we had to be careful what was included in it. This made it difficult to
add more helpers since the bar was so high. Another desired feature was
to be able to compile out the helpers for prod builds. This isn't
possible if the helpers are in `nerves_runtime`. This change removes the
helpers and leaves a note for anyone who has the helpers automatically
being included in an `iex.exs` file so that updating `nerves_runtime`
doesn't accidentally break their build.

Fixes #32.