### PR TITLE
Always use a keyword list for Uevent options

### DIFF
--- a/lib/nerves_runtime/application.ex
+++ b/lib/nerves_runtime/application.ex
@@ -35,7 +35,7 @@ defmodule Nerves.Runtime.Application do
   end
 
   defp target_children(_target) do
-    kernel_opts = Application.get_env(:nerves_runtime, :kernel)
+    kernel_opts = Application.get_env(:nerves_runtime, :kernel, [])
 
     [
       KmsgTailer,

--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -7,13 +7,13 @@ defmodule Nerves.Runtime.Kernel.UEvent do
   GenServer that captures Linux uevent messages and passes them up to Elixir.
   """
 
-  @spec start_link(any()) :: GenServer.on_start()
+  @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
   def init(opts) do
-    autoload = if opts[:autoload_modules] != nil, do: opts[:autoload_modules], else: true
+    autoload = Keyword.get(opts, :autoload_modules, true)
     send(self(), :discover)
     executable = :code.priv_dir(:nerves_runtime) ++ '/uevent'
 


### PR DESCRIPTION
I got tricked by the `start_link` call thinking that UEvent always got a list. It was being sent a nil. This change changes where the nil was coming from and tightens the spec to make things more clear.