### PR TITLE
Fence off text that looks like HTML

### DIFF
--- a/lib/nerves_runtime/log/parser.ex
+++ b/lib/nerves_runtime/log/parser.ex
@@ -9,7 +9,9 @@ defmodule Nerves.Runtime.Log.Parser do
 
   The message is of the form:
 
+  ```text
   <pri>message
+  ```
 
   `pri` is an integer that when broken apart gives you a facility and severity.
   `message` is everything else.


### PR DESCRIPTION
This fixes a warning when generating the docs.