### PR TITLE
Avoid copy through userland

### DIFF
--- a/src/kmsg_tailer.c
+++ b/src/kmsg_tailer.c
@@ -2,12 +2,11 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <sys/sendfile.h>
 #include <unistd.h>
 
 #define KMSG_PATH "/proc/kmsg"
 #define BUFFER_SIZE 4096
-
-static char buffer[BUFFER_SIZE];
 
 int main(int argc, char *argv[])
 {
@@ -16,11 +15,8 @@ int main(int argc, char *argv[])
         err(EXIT_FAILURE, "open %s", KMSG_PATH);
 
     for (;;) {
-        ssize_t amt = read(fd, buffer, sizeof(buffer));
+        ssize_t amt = sendfile(STDOUT_FILENO, fd, NULL, BUFFER_SIZE);
         if (amt < 0)
-            err(EXIT_FAILURE, "%s: read", argv[1]);
-
-        if (write(STDOUT_FILENO, buffer, amt) < 0)
-            err(EXIT_FAILURE, "%s: write", argv[1]);
+            err(EXIT_FAILURE, "%s: sendfile", argv[1]);
     }
 }


### PR DESCRIPTION
Use sendfile(2) to avoid copying kernel log messages through the
kmsg_tailer userland application and avoid the need for the temporary
buffer.