### PR TITLE
Move the initial uevent discovery trigger to C

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,15 @@ CFLAGS += -std=gnu99
 
 ifeq ($(origin CROSSCOMPILE), undefined)
 SUDO_ASKPASS ?= /usr/bin/ssh-askpass
-SUDO ?= sudo
+SUDO ?= true
 
 # If not cross-compiling, then run sudo and suid the port binary
 # so that it's possible to debug
 update_perms = \
+	echo "Not crosscompiling. To test locally, the port binary needs extra permissions.";\
+	echo "Set SUDO=sudo to set permissions. The default is to skip this step.";\
+	echo "SUDO_ASKPASS=$(SUDO_ASKPASS)";\
+	echo "SUDO=$(SUDO)";\
 	SUDO_ASKPASS=$(SUDO_ASKPASS) $(SUDO) -- sh -c 'chown root:root $(1); chmod +s $(1)'
 else
 # If cross-compiling, then permissions need to be set some build system-dependent way

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ ifeq ($(CROSSCOMPILE),)
 	DEFAULT_TARGETS = $(PREFIX)
     endif
 endif
-DEFAULT_TARGETS ?= $(PREFIX) $(PREFIX)/uevent $(PREFIX)/kmsg_tailer
+DEFAULT_TARGETS ?= $(PREFIX) $(PREFIX)/nerves_runtime
 
 # Set Erlang-specific compile and linker flags
 ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR)
@@ -76,20 +76,14 @@ install: $(BUILD) $(DEFAULT_TARGETS)
 $(BUILD)/%.o: src/%.c
 	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<
 
-$(PREFIX)/uevent: $(BUILD)/uevent.o
+$(PREFIX)/nerves_runtime: $(BUILD)/nerves_runtime.o $(BUILD)/uevent.o $(BUILD)/kmsg_tailer.o
 	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
 	$(call update_perms, $@)
 
-$(PREFIX)/kmsg_tailer: $(BUILD)/kmsg_tailer.o
-	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
-
-$(PREFIX):
-	mkdir -p $@
-
-$(BUILD):
+$(PREFIX) $(BUILD):
 	mkdir -p $@
 
 clean:
-	$(RM) $(PREFIX)/uevent $(PREFIX)/kmsg_tailer $(BUILD)/*.o
+	$(RM) $(PREFIX)/nerves_runtime $(BUILD)/*.o
 
 .PHONY: all clean calling_from_make install

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ install: $(BUILD) $(DEFAULT_TARGETS)
 $(BUILD)/%.o: src/%.c
 	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<
 
-$(PREFIX)/nerves_runtime: $(BUILD)/nerves_runtime.o $(BUILD)/uevent.o $(BUILD)/kmsg_tailer.o
+$(PREFIX)/nerves_runtime: $(BUILD)/nerves_runtime.o $(BUILD)/uevent.o $(BUILD)/kmsg_tailer.o $(BUILD)/uevent_discover.o
 	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
 	$(call update_perms, $@)
 

--- a/lib/nerves_runtime/device.ex
+++ b/lib/nerves_runtime/device.ex
@@ -1,4 +1,6 @@
 defmodule Nerves.Runtime.Device do
+  require Logger
+
   @moduledoc """
   This is a utility module for triggering UEvents from the Linux kernel. You
   don't need to use it directly. See the README.md for receiving events when
@@ -11,49 +13,14 @@ defmodule Nerves.Runtime.Device do
   """
   @spec discover() :: :ok
   def discover() do
-    "/sys/devices"
-    |> find_all_uevent()
-    |> Enum.each(&invoke_uevent_action(&1, "add"))
-  end
+    cmd = Application.app_dir(:nerves_runtime, ["priv", "nerves_runtime"])
 
-  defp find_all_uevent(dir), do: find_all_uevent(dir, safe_ls(dir), [])
+    {_, code} = System.cmd(cmd, [], arg0: "uevent_discover")
 
-  defp find_all_uevent(_dir, [], acc), do: acc
-
-  defp find_all_uevent(dir, ["uevent" | rest], acc) do
-    abs_path = Path.join(dir, "uevent")
-    find_all_uevent(dir, rest, [abs_path | acc])
-  end
-
-  defp find_all_uevent(dir, [filename | rest], acc) do
-    abs_path = Path.join(dir, filename)
-
-    next_acc =
-      if true_dir?(abs_path) do
-        find_all_uevent(abs_path, safe_ls(abs_path), acc)
-      else
-        acc
-      end
-
-    find_all_uevent(dir, rest, next_acc)
-  end
-
-  defp true_dir?(path) do
-    # File.dir?/1 follows symlinks. true_dir?/1 does not.
-    case File.lstat(path) do
-      {:ok, stat} -> stat.type == :directory
-      _ -> false
+    if code != 0 do
+      Logger.error("Unexpected error from uevent discovery")
     end
-  end
 
-  defp safe_ls(path) do
-    case File.ls(path) do
-      {:ok, files} -> files
-      _ -> []
-    end
-  end
-
-  defp invoke_uevent_action(uevent, action) do
-    File.write(uevent, action)
+    :ok
   end
 end

--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -23,11 +23,11 @@ defmodule Nerves.Runtime.Kernel.UEvent do
     autoload = Keyword.get(opts, :autoload_modules, true)
     use_system_registry = Keyword.get(opts, :use_system_registry, true)
 
-    executable = :code.priv_dir(:nerves_runtime) ++ '/uevent'
+    executable = :code.priv_dir(:nerves_runtime) ++ '/nerves_runtime'
 
     port =
       Port.open({:spawn_executable, executable}, [
-        {:args, []},
+        {:arg0, "uevent"},
         {:packet, 2},
         :use_stdio,
         :binary,

--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -36,6 +36,7 @@ defmodule Nerves.Runtime.Kernel.UEvent do
 
     # Trigger uevent messages to be sent for all devices that have been enumerated
     # by the Linux kernel before this GenServer started.
+    _ = Logger.debug("UEvent initial device discovery started")
     discover_task = Task.async(&Device.discover/0)
 
     {:ok,

--- a/lib/nerves_runtime/log/kmsg_tailer.ex
+++ b/lib/nerves_runtime/log/kmsg_tailer.ex
@@ -37,6 +37,7 @@ defmodule Nerves.Runtime.Log.KmsgTailer do
 
   defp open_port() do
     Port.open({:spawn_executable, executable()}, [
+      {:arg0, "kmsg_tailer"},
       {:line, 1024},
       :use_stdio,
       :binary,
@@ -45,7 +46,7 @@ defmodule Nerves.Runtime.Log.KmsgTailer do
   end
 
   defp executable() do
-    :code.priv_dir(:nerves_runtime) ++ '/kmsg_tailer'
+    :code.priv_dir(:nerves_runtime) ++ '/nerves_runtime'
   end
 
   defp handle_message(raw_entry) do

--- a/src/kmsg_tailer.c
+++ b/src/kmsg_tailer.c
@@ -8,7 +8,7 @@
 #define KMSG_PATH "/proc/kmsg"
 #define BUFFER_SIZE 4096
 
-int main(int argc, char *argv[])
+int kmsg_tailer_main(int argc, char *argv[])
 {
     int fd = open(KMSG_PATH, O_RDONLY);
     if (fd < 0)

--- a/src/kmsg_tailer.c
+++ b/src/kmsg_tailer.c
@@ -2,12 +2,11 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <sys/sendfile.h>
 #include <unistd.h>
 
 #define KMSG_PATH "/proc/kmsg"
 #define BUFFER_SIZE 4096
-
-static char buffer[BUFFER_SIZE];
 
 int main(int argc, char *argv[])
 {
@@ -16,11 +15,8 @@ int main(int argc, char *argv[])
         err(EXIT_FAILURE, "open %s", KMSG_PATH);
 
     for (;;) {
-        ssize_t amt = read(fd, buffer, sizeof(buffer));
+        ssize_t amt = sendfile(STDOUT_FILENO, fd, NULL, BUFFER_SIZE);
         if (amt < 0)
-            err(EXIT_FAILURE, "%s: read", argv[1]);
-
-        if (write(STDOUT_FILENO, buffer, amt) < 0)
-            err(EXIT_FAILURE, "%s: write", argv[1]);
+            err(EXIT_FAILURE, "%s: sendfile", argv[1]);
     }
 }

--- a/src/nerves_runtime.c
+++ b/src/nerves_runtime.c
@@ -1,0 +1,16 @@
+#include <err.h>
+#include <string.h>
+#include <stdlib.h>
+
+int uevent_main(int argc, char *argv[]);
+int kmsg_tailer_main(int argc, char *argv[]);
+
+int main(int argc, char *argv[])
+{
+    if (strcmp(argv[0], "uevent") == 0)
+        return uevent_main(argc, argv);
+    else if (strcmp(argv[0], "kmsg_tailer") == 0)
+        return kmsg_tailer_main(argc, argv);
+    else
+        errx(EXIT_FAILURE, "Unexpected name: %s", argv[0]);
+}

--- a/src/nerves_runtime.c
+++ b/src/nerves_runtime.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 int uevent_main(int argc, char *argv[]);
+int uevent_discover_main(int argc, char *argv[]);
 int kmsg_tailer_main(int argc, char *argv[]);
 
 int main(int argc, char *argv[])
@@ -11,6 +12,8 @@ int main(int argc, char *argv[])
         return uevent_main(argc, argv);
     else if (strcmp(argv[0], "kmsg_tailer") == 0)
         return kmsg_tailer_main(argc, argv);
+    else if (strcmp(argv[0], "uevent_discover") == 0)
+        return uevent_discover_main(argc, argv);
     else
         errx(EXIT_FAILURE, "Unexpected name: %s", argv[0]);
 }

--- a/src/uevent.c
+++ b/src/uevent.c
@@ -222,7 +222,7 @@ static void nl_uevent_process(struct netif *nb)
     erlcmd_send(nb->resp, nb->resp_index);
 }
 
-int main(int argc, char *argv[])
+int uevent_main(int argc, char *argv[])
 {
     (void) argc;
     (void) argv;

--- a/src/uevent_discover.c
+++ b/src/uevent_discover.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <dirent.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+
+static int filter(const struct dirent *dirp)
+{
+    return (dirp->d_type == DT_REG && strcmp(dirp->d_name, "uevent") == 0) ||
+           (dirp->d_type == DT_DIR && dirp->d_name[0] != '.');
+}
+
+static void scandirs(char *path, int path_end)
+{
+    struct dirent **namelist;
+    int n;
+
+    n = scandir(path, &namelist, filter, NULL);
+    if (n < 0)
+        return;
+
+    path[path_end] = '/';
+
+    int i;
+    for (i = 0; i < n; i++) {
+        strcpy(&path[path_end + 1], namelist[i]->d_name);
+        if (namelist[i]->d_type == DT_DIR) {
+            scandirs(path, strlen(path));
+        } else {
+            int fd = open(path, O_WRONLY);
+            if (fd >= 0) {
+                write(fd, "add", 3);
+                close(fd);
+            }
+        }
+        free(namelist[i]);
+    }
+    free(namelist);
+    path[path_end] = 0;
+
+}
+
+int uevent_discover_main(int argc, char **argv)
+{
+    char path[PATH_MAX] = "/sys/devices";
+    scandirs(path, strlen(path));
+}
+


### PR DESCRIPTION
This change greatly reduces syscalls for the initial device discovery
and discovery completes 10 seconds earlier on a simple Raspberry Pi
Zero build. This change does not appear to affect how early a user can
log into Elixir CLI, though.