### PR TITLE
Use absolute path to modprobe

### DIFF
--- a/lib/nerves_runtime/kernel/uevent.ex
+++ b/lib/nerves_runtime/kernel/uevent.ex
@@ -121,7 +121,7 @@ defmodule Nerves.Runtime.Kernel.UEvent do
   end
 
   defp modprobe(%{"modalias" => modalias}) do
-    System.cmd("modprobe", [modalias], stderr_to_stdout: true)
+    System.cmd("/sbin/modprobe", [modalias], stderr_to_stdout: true)
   end
 
   defp modprobe(_), do: :noop


### PR DESCRIPTION
This removes the path lookup for modprobe and prevents someone from
putting an alternative modprobe earlier in the path lookup.