### PR TITLE
Handle uevent overload more gracefully

### DIFF
--- a/src/uevent.c
+++ b/src/uevent.c
@@ -148,8 +148,13 @@ static int ei_encode_devpath(char * buf, int *index, char *devpath, char **end_d
 static void nl_uevent_process(struct netif *nb)
 {
     int bytecount = mnl_socket_recvfrom(nb->nl_uevent, nb->nlbuf, sizeof(nb->nlbuf));
-    if (bytecount <= 0)
+    if (bytecount <= 0) {
+        if (errno == ENOBUFS) {
+            warnx("mnl_socket_recvfrom dropped message - possible overload");
+            return;
+        }
         err(EXIT_FAILURE, "mnl_socket_recvfrom");
+    }
 
     char *str = nb->nlbuf;
     char *str_end = str + bytecount;

--- a/src/utils.h
+++ b/src/utils.h
@@ -27,7 +27,7 @@ FILE *log_location;
 #define debug(...) do { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\r\n"); fflush(stderr); } while(0)
 #else
 #define LOG_LOCATION stderr
-#define debug(...)
+#define debug(...) do {} while(0)
 #endif
 
 #endif // UTIL_H


### PR DESCRIPTION
I can only reproduce an overload on a 32-core x86_64 machine. What
happens is that libmnl returns an error from the recv call that
indicates that the kernel internally has dropped a notification. The
overload is triggered in the initial scan of hardware. It seems like it
should be impossible to trigger in any other real hardware insertion and
removal scenario.

Before this fix, the behavior was to exit the port process. This would
cause it to be re-started due to supervision. Since the hardware scan
must happen again since devices could have been inserted between the
crash and the restart, the scan is kicked off and the port process exits
again. Restart intensity is reached and total failure. Losing one or two
notifications bothers me greatly, but it seems like a far better
solution than crashing.

I suspect that this has not been seen in the field since the number of
devices on most embedded systems is far less than on this 32-core
machine.

