### PR TITLE
Fix compiler error from PATH_MAX

### DIFF
--- a/src/uevent.c
+++ b/src/uevent.c
@@ -30,6 +30,7 @@
 
 #include <libmnl/libmnl.h>
 #include <linux/rtnetlink.h>
+#include <linux/limits.h>
 
 #include <ei.h>
 


### PR DESCRIPTION
This seems to only affect the x86_64 system. The error is:

```
src/uevent.c: In function 'uevent_discover':
src/uevent.c:276:19: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'AF_MAX'?
         char path[PATH_MAX] = "/sys/devices";
                   ^~~~~~~~
                   AF_MAX
```