### PR TITLE
Add API to KV for writing to the firmware metadata

### DIFF
--- a/lib/nerves_runtime/kv/mock.ex
+++ b/lib/nerves_runtime/kv/mock.ex
@@ -18,4 +18,6 @@ defmodule Nerves.Runtime.KV.Mock do
 
   def init_state(state) when is_map(state), do: state
   def init_state(_state), do: %{}
+
+  def put(_), do: :ok
 end

--- a/lib/nerves_runtime/kv/uboot_env.ex
+++ b/lib/nerves_runtime/kv/uboot_env.ex
@@ -11,10 +11,14 @@ defmodule Nerves.Runtime.KV.UBootEnv do
   end
 
   def put(key, value) do
+    put(%{key => value})
+  end
+
+  def put(%{} = kv) do
     case UBootEnv.read() do
-      {:ok, kv} ->
-        kv
-        |> Map.put(key, value)
+      {:ok, current_kv} ->
+        current_kv
+        |> Map.merge(kv)
         |> UBootEnv.write()
 
       error ->


### PR DESCRIPTION
This PR closes #136 by adding a public API to the KV module for updating the firmware metadata.

The PR is not quite done (the doctests are broken and I haven't added new tests), but  I'd like to hear if I am taking this in the right direction.

Specifically, the API here does not support putting a key to the active partition by automatically adding the slot prefix. Should this be added to mirror `get_active/1`?

