### PR TITLE
Clarify docs for using Nerves.Runtime.KV.Mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,38 @@ for how to assign serial numbers to devices.
 ## Using nerves_runtime in tests
 
 Applications that depend on `nerves_runtime` for accessing provisioning
-information from the `Nerves.Runtime.KV` can mock the contents through the
-Application config.
+information from the `Nerves.Runtime.KV` can mock the contents with the
+included `Nerves.Runtime.KV.Mock` module through the Application config:
 
 ```elixir
+config :nerves_runtime, Nerves.Runtime.KV.Mock, %{"key" => "value"}
+```
+
+You can also create your own module based on the `Nerves.Runtime.KV` behavior
+and set it to be used in the Application config. In most situations, the
+provided `Nerves.Runtime.KV.Mock` should be sufficient, though this would be
+helpful in cases where you might need to generate the inital state at
+runtime instead:
+
+```elixir
+defmodule MyApp.KV.Mock do
+  @behaviour Nerves.Runtime.KV
+
+  @impl true
+  def init(_opts) do
+    # initial state
+    %{
+      "howdy" => "partner",
+      "dynamic" => some_runtime_calc_function()
+    }
+  end
+
+  @impl true
+  def put(_map), do: :ok
+end
+
+# Then in config.exs
 config :nerves_runtime, :modules, [
-  {Nerves.Runtime.KV.Mock, %{"key" => "value"}}
+  {Nerves.Runtime.KV, MyApp.KV.Mock}
 ]
 ```

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -126,6 +126,7 @@ defmodule Nerves.Runtime.KV do
   require Logger
 
   @callback init(opts :: any) :: initial_state :: map
+  @callback put(state :: map) :: :ok | {:error, reason :: any()}
 
   alias __MODULE__
 

--- a/lib/nerves_runtime/kv/mock.ex
+++ b/lib/nerves_runtime/kv/mock.ex
@@ -7,11 +7,10 @@ defmodule Nerves.Runtime.KV.Mock do
   Application config.
 
   ```elixir
-  config :nerves_runtime, :modules, [
-    {Nerves.Runtime.KV.Mock, %{"key" => "value"}}
-  ]
+  config :nerves_runtime, Nerves.Runtime.KV.Mock, %{"key" => "value"}
   ```
   """
+  @impl true
   def init(state) do
     Application.get_env(:nerves_runtime, __MODULE__) || init_state(state)
   end
@@ -19,5 +18,6 @@ defmodule Nerves.Runtime.KV.Mock do
   def init_state(state) when is_map(state), do: state
   def init_state(_state), do: %{}
 
+  @impl true
   def put(_), do: :ok
 end


### PR DESCRIPTION
I noticed that the old way of setting mock data is not longer supported. So this changes the docs with the correct way of specifying KV.Mock data.

Also adds `@callback put(state)` module attribute in `Nerves.Runtime.KV` since that is now a function which will be called on the dynamically defined module and should be expected in the contract.