### PR TITLE
Fix exception on init when mounting the application data partition

### DIFF
--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -2,7 +2,7 @@ defmodule Nerves.Runtime.Init do
   use GenServer
   require Logger
   alias Nerves.Runtime
-  alias Nerves.Runtime.{KV, OutputLogger}
+  alias Nerves.Runtime.KV
 
   @moduledoc """
   GenServer that handles device initialization.
@@ -145,14 +145,11 @@ defmodule Nerves.Runtime.Init do
 
   defp check_cmd(cmd, args, out) do
     case Runtime.cmd(cmd, args, out) do
-      {0, _} ->
+      {_, 0} ->
         :ok
 
-      {%OutputLogger{}, _} ->
-        :ok
-
-      {status, _} ->
-        _ = Logger.warn("Ignoring non-zero exit status (#{status}) from #{cmd} #{inspect(args)}")
+      _ ->
+        _ = Logger.warn("Ignoring non-zero exit status from #{cmd} #{inspect(args)}")
         :ok
     end
   end


### PR DESCRIPTION
This also fixes the pattern mismatch for the return status code.

This addresses an issue where :nerves_runtime would exit due to an unmatched call to System.cmd/3.

Initially reported: https://elixirforum.com/t/missing-essential-processes-in-nerves-system/22945