### PR TITLE
Log and return an error if a command isn't found

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,4 +1,4 @@
 [
   # NervesRuntime.logged_shutdown isn't supposed to return
-  {"lib/nerves_runtime.ex", :no_return, 93}
+  {"lib/nerves_runtime.ex", :no_return, 110}
 ]


### PR DESCRIPTION
Previously this would raise and eventually cause `nerves_runtime` to be
stopped. This would stop RingLogger which would make seeing the error
message really hard. Errors are still returned and log messages written
so it should be easier to spot missing commands in Nerves systems in the
future.