### PR TITLE
Increase uevent path segments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
 
 ifeq ($(MIX_COMPILE_PATH),)
-	$(error MIX_COMPILE_PATH should be set by elixir_make!)
+    $(error MIX_COMPILE_PATH should be set by elixir_make!)
 endif
 
 PREFIX = $(MIX_COMPILE_PATH)/../priv

--- a/src/uevent.c
+++ b/src/uevent.c
@@ -108,7 +108,7 @@ static int ei_encode_devpath(char * buf, int *index, char *devpath, char **end_d
             p++;
             segments[segment_ix] = p;
             segment_ix++;
-            if (segment_ix > MAX_SEGMENTS) {
+            if (segment_ix >= MAX_SEGMENTS) {
                 while (*p != '\0') p++;
                 break;
             }

--- a/src/uevent.c
+++ b/src/uevent.c
@@ -96,7 +96,7 @@ static int ei_encode_devpath(char * buf, int *index, char *devpath, char **end_d
     // Skip the root slash
     devpath++;
 
-#define MAX_SEGMENTS 16
+#define MAX_SEGMENTS 32
     char *segments[MAX_SEGMENTS];
     segments[0] = devpath;
 


### PR DESCRIPTION
This PR increases the number of uevent path segments from 16 to 32 and fixes an error where the uevent port could construct a malformed term and cause the uevent port process to exit with an Argument error when trying to decode the binary to terms.