### PR TITLE
Switch to MIX_APP_PATH; remove unneeded check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 # Variables to override:
 #
-# MIX_COMPILE_PATH path to the build's ebin directory
+# MIX_APP_PATH  path to the build directory
 #
 # CC            C compiler
 # CROSSCOMPILE	crosscompiler prefix, if any
@@ -18,12 +18,8 @@
 # LDFLAGS	linker flags for linking all binaries
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
 
-ifeq ($(MIX_COMPILE_PATH),)
-    $(error MIX_COMPILE_PATH should be set by elixir_make!)
-endif
-
-PREFIX = $(MIX_COMPILE_PATH)/../priv
-BUILD  = $(MIX_COMPILE_PATH)/../obj
+PREFIX = $(MIX_APP_PATH)/priv
+BUILD  = $(MIX_APP_PATH)/obj
 
 # Check that we're on a supported build platform
 ifeq ($(CROSSCOMPILE),)

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Nerves.Runtime.MixProject do
   defp deps do
     [
       {:system_registry, "~> 0.5"},
-      {:elixir_make, "~> 0.5", runtime: false},
+      {:elixir_make, "~> 0.6", runtime: false},
       {:uboot_env, "~> 0.1"},
       {:ex_doc, "~> 0.18", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false}


### PR DESCRIPTION
Using MIX_APP_PATH cleans up the paths that get printed when building.

This also removes the check for whether `make` is being called directly,
since the Makefile is smart enough to detect this and call `mix`
automatically if this happens.