### PR TITLE
fixes an issue building nerves_runtime when the parent directory contains spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,10 @@
 # LDFLAGS	linker flags for linking all binaries
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
 
-PREFIX = $(MIX_APP_PATH)/priv
-BUILD  = $(MIX_APP_PATH)/obj
+MIX_PATH = $(shell echo $(MIX_APP_PATH) | sed -e 's/ /\\/g' )
+
+PREFIX = $(MIX_PATH)/priv
+BUILD  = $(MIX_PATH)/obj
 
 # Check that we're on a supported build platform
 ifeq ($(CROSSCOMPILE),)


### PR DESCRIPTION
This will enable the nerves_runtime to be built when the parent directory contains a space in it as reflected in issue #31