### PR TITLE
Add O_CLOEXEC proactively

### DIFF
--- a/src/kmsg_tailer.c
+++ b/src/kmsg_tailer.c
@@ -29,7 +29,7 @@ int kmsg_tailer_main(int argc, char *argv[])
     (void) argc;
     (void) argv;
 
-    int fd = open(KMSG_PATH, O_RDONLY);
+    int fd = open(KMSG_PATH, O_RDONLY | O_CLOEXEC);
     if (fd < 0)
         err(EXIT_FAILURE, "open %s", KMSG_PATH);
 

--- a/src/uevent.c
+++ b/src/uevent.c
@@ -60,7 +60,7 @@ static void write_all(char *response, size_t len)
 
 static struct mnl_socket *uevent_open()
 {
-    struct mnl_socket *nl_uevent = mnl_socket_open2(NETLINK_KOBJECT_UEVENT, O_NONBLOCK);
+    struct mnl_socket *nl_uevent = mnl_socket_open2(NETLINK_KOBJECT_UEVENT, O_NONBLOCK | O_CLOEXEC);
     if (!nl_uevent)
         err(EXIT_FAILURE, "mnl_socket_open (NETLINK_KOBJECT_UEVENT)");
 


### PR DESCRIPTION
Just in case there's ever a fork/exec added in the future, O_CLOEXEC
will already be around to close open file handles.