### PR TITLE
Support uboot_env 0.2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Nerves.Runtime.MixProject do
   defp deps do
     [
       {:system_registry, "~> 0.8.0"},
-      {:uboot_env, "~> 0.1.1"},
+      {:uboot_env, "~> 0.1.1 or ~> 0.2.0"},
       {:elixir_make, "~> 0.6", runtime: false},
       {:ex_doc, "~> 0.18", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -8,5 +8,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
   "system_registry": {:hex, :system_registry, "0.8.2", "df791dc276652fcfb53be4dab823e05f8269b96ac57c26f86a67838dbc0eefe7", [:mix], [], "hexpm", "f7acdede22c73ab0b3735eead7f2095efb2a7a6198366564205274db2ca2a8f8"},
-  "uboot_env": {:hex, :uboot_env, "0.1.1", "b01e3ec0973e99473234f27839e29e63b5b81eba6a136a18a78d049d4813d6c5", [:mix], [], "hexpm", "f7b82da0cb40c8db9c9fb1fc977780ab0c28d961ec1f3c7ab265c4352e4141ae"},
+  "uboot_env": {:hex, :uboot_env, "0.2.0", "003a8e7688b59a072fc0a849963622f45bb9efedce9af6ae3a52ba7c6a06149a", [:mix], [], "hexpm", "891d30fbd4795c242418f2430460f52e2c050bbf3e31c64f22ab87b6f10287ee"},
 }


### PR DESCRIPTION
uboot_env 0.2.0 contains a breaking change from 0.1.1, but the breaking
change does not affect nerves_runtime. This commit makes it possible to
use either version.

The main reason to update to 0.2.0 is that it significantly reduces the
amount of memory garbage that gets generated when parsing and writing
environment blocks. On one production system the garbage created was in
the low megabytes which one easily bump any process that called
uboot_env to the top of the list.