### PR TITLE
Autovalidate fw on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ Key                 | Build Environment Variable   | Example Value    | Descript
 `nerves_fw_devpath` | `NERVES_FW_DEVPATH`          | `"/dev/mmcblk0"` | This is the primary storage device for the firmware.
 `nerves_serial_number` | N/A                       | `"12345abc"`     | This is a text serial number. See [Serial numbers](#serial_numbers) for details.
 `nerves_fw_validated` | N/A                        | `0`              | Set to "1" to indicate that the currently running firmware is valid. (Only supported on some platforms)
-`nerves_fw_autovalidate` | N/A                     | `1`              | Set to "1" to indicate that firmware updates are valid without any additional checks.  (Only supported on some platforms)
 
 Firmware-specific Nerves metadata includes the following:
 
@@ -209,9 +208,14 @@ Here's the process:
 6. On error, the reboot timer failing, or a hardware watchdog timeout, the
    system reboots. The bootloader reverts to the previous firmware.
 
-To use this feature, the `nerves_fw_autovalidate` variable must be set to 0. This
-can be done at device provisioning time (like when the serial number is set) or
-inside a custom `fwup.conf`.
+By default, `Nerves.Runtime` sets `nerves_fw_validated` on first boot. However,
+you can disable this in order to allow your application logic to do something
+like the example above for determining if the firmware is valid or not.
+To disable, change your configuration to:
+
+```elixir
+config :nerves_runtime, validate_firmware: false
+```
 
 ### Best effort automatic revert
 


### PR DESCRIPTION
Currently only a few systems used `nerves_fw_validated` and its  a manual process in `fwup.conf` to setup and check in the context of autoreverts. Then that variable gets checked on next boot to determine if a revert should happen.

However, I think this is a little too early in the startup (i.e. we immediately set this variable, but something later in the startup but before runtime fails).

So this sets it during initialization of `Nerves.Runtime` to help catch that zone of errors that might otherwise be missed. If we're to this initialization, we're pretty confident the fw is good.

It also allows disabling autovalidation in the config so that the application can handle the logic check even later.

Also, I didn't change any documentation because it needs a pretty big overhaul. I have a working concept of auto revert working for `rpi` systems and want to get some of that up, then sweep through this area of documentation at once