### PR TITLE
Remove _ = on all Logger calls

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,4 +1,4 @@
 [
   # NervesRuntime.logged_shutdown isn't supposed to return
-  {"lib/nerves_runtime.ex", :no_return, 139}
+  {"lib/nerves_runtime.ex", :no_return, 138}
 ]

--- a/lib/nerves_runtime.ex
+++ b/lib/nerves_runtime.ex
@@ -107,10 +107,9 @@ defmodule Nerves.Runtime do
   def cmd(cmd, params, log_level_or_return) do
     case System.find_executable(cmd) do
       nil ->
-        _ =
-          Logger.error(
-            "Executable #{cmd} was not found. The Nerves System must be fixed to include it!"
-          )
+        Logger.error(
+          "Executable #{cmd} was not found. The Nerves System must be fixed to include it!"
+        )
 
         {"", 255}
 
@@ -137,7 +136,7 @@ defmodule Nerves.Runtime do
   @spec logged_shutdown(String.t()) :: no_return()
   defp logged_shutdown(cmd) do
     try do
-      _ = Logger.info("#{__MODULE__} : device told to #{cmd}")
+      Logger.info("#{__MODULE__} : device told to #{cmd}")
 
       # Invoke the appropriate command to tell erlinit that a shutdown of the
       # Erlang VM is imminent. Once this returns, the Erlang has about 10

--- a/lib/nerves_runtime/application.ex
+++ b/lib/nerves_runtime/application.ex
@@ -54,7 +54,7 @@ defmodule Nerves.Runtime.Application do
           true
 
         {reason, _non_zero_exit} ->
-          _ = Logger.warn("Failed to start #{name}: #{inspect(reason)}")
+          Logger.warn("Failed to start #{name}: #{inspect(reason)}")
           false
       end
     else

--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -137,10 +137,9 @@ defmodule Nerves.Runtime.Init do
   defp unmount_if_error(s), do: s
 
   defp format_if_unmounted(%{mounted: :unmounted, fstype: fstype, devpath: devpath} = s) do
-    _ =
-      Logger.warn(
-        "Formatting application partition. If this hangs, it could be waiting on the urandom pool to be initialized"
-      )
+    Logger.warn(
+      "Formatting application partition. If this hangs, it could be waiting on the urandom pool to be initialized"
+    )
 
     mkfs(fstype, devpath)
     s
@@ -162,7 +161,7 @@ defmodule Nerves.Runtime.Init do
         :ok
 
       _ ->
-        _ = Logger.warn("Ignoring non-zero exit status from #{cmd} #{inspect(args)}")
+        Logger.warn("Ignoring non-zero exit status from #{cmd} #{inspect(args)}")
         :ok
     end
   end

--- a/lib/nerves_runtime/log/kmsg_tailer.ex
+++ b/lib/nerves_runtime/log/kmsg_tailer.ex
@@ -54,14 +54,13 @@ defmodule Nerves.Runtime.Log.KmsgTailer do
       {:ok, %{facility: facility, severity: severity, message: message}} ->
         level = SyslogParser.severity_to_logger(severity)
 
-        _ =
-          Logger.bare_log(
-            level,
-            message,
-            module: __MODULE__,
-            facility: facility,
-            severity: severity
-          )
+        Logger.bare_log(
+          level,
+          message,
+          module: __MODULE__,
+          facility: facility,
+          severity: severity
+        )
 
       _ ->
         # We don't handle continuations and multi-line kmsg logs.

--- a/lib/nerves_runtime/log/syslog_tailer.ex
+++ b/lib/nerves_runtime/log/syslog_tailer.ex
@@ -39,23 +39,19 @@ defmodule Nerves.Runtime.Log.SyslogTailer do
       {:ok, %{facility: facility, severity: severity, message: message}} ->
         level = SyslogParser.severity_to_logger(severity)
 
-        _ =
-          Logger.bare_log(
-            level,
-            message,
-            module: __MODULE__,
-            facility: facility,
-            severity: severity
-          )
-
-        :ok
+        Logger.bare_log(
+          level,
+          message,
+          module: __MODULE__,
+          facility: facility,
+          severity: severity
+        )
 
       _ ->
         # This is unlikely to ever happen, but if a message was somehow
         # malformed and we couldn't parse the syslog priority, we should
         # still do a best-effort to pass along the raw data.
-        _ = Logger.warn("Malformed syslog report: #{inspect(raw_entry)}")
-        :ok
+        Logger.warn("Malformed syslog report: #{inspect(raw_entry)}")
     end
 
     {:noreply, log_port}


### PR DESCRIPTION
Elixir 1.10's Logger calls only return :ok now, so the return value no
longer needs to be ignored to make Dialyzer happy.