### PR TITLE
Switch firmware validation logic to off by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,17 @@ Here's the process:
 6. On error, the reboot timer failing, or a hardware watchdog timeout, the
    system reboots. The bootloader reverts to the previous firmware.
 
-By default, `Nerves.Runtime` sets `nerves_fw_validated` on first boot. However,
-you can disable this in order to allow your application logic to do something
-like the example above for determining if the firmware is valid or not.
-To disable, change your configuration to:
+The automatic revert feature's implementation is split across a Nerves System
+and your application. The system, which contains your device's bootloader and
+Linux kernel, needs to decide which firmware to boot (new or old one). Your
+application is responsible for setting the `nerves_fw_validated` flag
+appropriately. This makes reusing "automatic revert"-enabled Nerves systems
+inconvenient to use for small projects. `NervesRuntime` can assist by validating
+your firmware after it initializes itself. To enable, add the following line to
+your configuration:
 
 ```elixir
-config :nerves_runtime, validate_firmware: false
+config :nerves_runtime, validate_firmware: true
 ```
 
 ### Best effort automatic revert

--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -169,9 +169,8 @@ defmodule Nerves.Runtime.Init do
   defp validate_mount(s), do: s.mounted
 
   defp maybe_validate_fw() do
-    validated? = KV.get("nerves_fw_validated") == "1"
-
-    if Application.get_env(:nerves_runtime, :validate_firmware, true) && not validated? do
+    if Application.get_env(:nerves_runtime, :validate_firmware, false) &&
+         KV.get("nerves_fw_validated") == "0" do
       KV.put("nerves_fw_validated", "1")
     end
   end


### PR DESCRIPTION
I've been struggling with the automatic firmware validate logic since the default was "on". It seems like you'd only want it to be enabled in toy projects. And worse, if you were to accidentally enable it in a production project, you could circumvent a more involved validation check.

I did have another thought which is to delete the feature and have people put `Nerves.Runtime.KV.put("nerves_fw_validated", "1")` or maybe wrap it and put `Nerves.Runtime.validate_firmware()` in their main application. That could be part of the new project generator too.

I suppose that it depends on whether people like stuff in `config.exs` or their main application code better. 