### PR TITLE
Revert auto-validate code

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Key                 | Build Environment Variable   | Example Value    | Descript
 `nerves_fw_devpath` | `NERVES_FW_DEVPATH`          | `"/dev/mmcblk0"` | This is the primary storage device for the firmware.
 `nerves_serial_number` | N/A                       | `"12345abc"`     | This is a text serial number. See [Serial numbers](#serial_numbers) for details.
 `nerves_fw_validated` | N/A                        | `0`              | Set to "1" to indicate that the currently running firmware is valid. (Only supported on some platforms)
+`nerves_fw_autovalidate` | N/A                     | `1`              | Set to "1" to indicate that firmware updates are valid without any additional checks.  (Only supported on some platforms)
 
 Firmware-specific Nerves metadata includes the following:
 
@@ -208,14 +209,9 @@ Here's the process:
 6. On error, the reboot timer failing, or a hardware watchdog timeout, the
    system reboots. The bootloader reverts to the previous firmware.
 
-By default, `Nerves.Runtime` sets `nerves_fw_validated` on first boot. However,
-you can disable this in order to allow your application logic to do something
-like the example above for determining if the firmware is valid or not.
-To disable, change your configuration to:
-
-```elixir
-config :nerves_runtime, validate_firmware: false
-```
+To use this feature, the `nerves_fw_autovalidate` variable must be set to 0. This
+can be done at device provisioning time (like when the serial number is set) or
+inside a custom `fwup.conf`.
 
 ### Best effort automatic revert
 

--- a/README.md
+++ b/README.md
@@ -200,18 +200,25 @@ the firmware update server within 5 minutes of boot?"
 Here's the process:
 
 1. New firmware is installed in the normal manner. The `Nerves.Runtime.KV`
-   variable, `nerves_fw_validated` is set to 0.
+   variable, `nerves_fw_validated` is set to 0. (The systems `fwup.conf` does
+   this)
 2. The system reboots like normal.
-3. The device starts a five minute reboot timer (your code needs to do this)
+3. The device starts a five minute reboot timer (your code needs to do this if
+   you want to catch hangs or super-slow boots)
 4. The application attempts to make a connection to the firmware update server.
-5. On a good connection, the application sets `nerves_fw_validated` to 1 and
-   cancels the reboot timer.
+5. On a good connection, the application sets `nerves_fw_validated` to 1 by
+   calling `Nerves.Runtime.validate_firmware/0` and cancels the reboot timer.
 6. On error, the reboot timer failing, or a hardware watchdog timeout, the
    system reboots. The bootloader reverts to the previous firmware.
 
-To use this feature, the `nerves_fw_autovalidate` variable must be set to 0. This
-can be done at device provisioning time (like when the serial number is set) or
-inside a custom `fwup.conf`.
+Some Nerves systems support a KV variable called `nerves_fw_autovalidate`. The
+intention of this variable was to make that system support scenarios that
+require validate and ones that don't. If the system supports this variable then
+you should make sure that it is set to 0 (either via a custom fwup.conf or via
+the provisioning hooks for writing serial numbers to MicroSD cards). Support for
+the `nerves_fw_autovalidate` variable will likely go away in the future as steps
+are made to make automatic revert on bad firmware a default feature of Nerves
+rather than an add-on.
 
 ### Best effort automatic revert
 

--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -11,7 +11,6 @@ defmodule Nerves.Runtime.Init do
 
   1. Mounting the application partition
   2. If the application partition can't be mounted, format it, and then mount it.
-  3. Validates the firmware
 
   Device initialization is usually a first boot only operation. It's possible
   that device filesystems get corrupt enough to cause them to be reinitialized.
@@ -25,17 +24,6 @@ defmodule Nerves.Runtime.Init do
   have also had stalls when formatting while waiting for enough entropy to
   generate a UUID. Look into hardcoding UUIDs or enabling a hw random number
   generator to increase entropy.
-
-  Nerves considers the firmware valid if it gets to this point and so
-  `nerves_fw_validated` UBoot env variable gets set by default so it can be used
-  in revert logic on subsequent reboots. If you wish to handle the logic
-  of firmware validity with your own conditions (i.e. requiring internet connectivity,
-  sensors to be detected, etc), you can disable this auto-validation to allow
-  your application checks later on:
-
-  ```
-  config :nerves_runtime, validate_firmware: false
-  ```
   """
 
   # Use a fixed UUID for the application partition. This has two
@@ -58,7 +46,6 @@ defmodule Nerves.Runtime.Init do
   @impl true
   def init(_args) do
     init_application_partition()
-    maybe_validate_fw()
     {:ok, %{}}
   end
 
@@ -167,12 +154,4 @@ defmodule Nerves.Runtime.Init do
   end
 
   defp validate_mount(s), do: s.mounted
-
-  defp maybe_validate_fw() do
-    validated? = KV.get("nerves_fw_validated") == "1"
-
-    if Application.get_env(:nerves_runtime, :validate_firmware, true) && not validated? do
-      KV.put("nerves_fw_validated", "1")
-    end
-  end
 end


### PR DESCRIPTION
Per #180, #184, #185 and other discussion, this reverts the autovalidate code and replaces it with some text about calling `Nerves.Runtime.validate_firmware/0` in your application.