### PR TITLE
Tighten up KV specs

### DIFF
--- a/lib/nerves_runtime/kv/mock.ex
+++ b/lib/nerves_runtime/kv/mock.ex
@@ -15,9 +15,9 @@ defmodule Nerves.Runtime.KV.Mock do
     Application.get_env(:nerves_runtime, __MODULE__) || init_state(state)
   end
 
-  def init_state(state) when is_map(state), do: state
-  def init_state(_state), do: %{}
+  defp init_state(state) when is_map(state), do: state
+  defp init_state(_state), do: %{}
 
   @impl Nerves.Runtime.KV
-  def put(_), do: :ok
+  def put(_new_state), do: :ok
 end

--- a/lib/nerves_runtime/kv/uboot_env.ex
+++ b/lib/nerves_runtime/kv/uboot_env.ex
@@ -3,6 +3,7 @@ defmodule Nerves.Runtime.KV.UBootEnv do
 
   @moduledoc false
 
+  @impl Nerves.Runtime.KV
   def init(_opts) do
     case UBootEnv.read() do
       {:ok, kv} -> kv
@@ -10,10 +11,7 @@ defmodule Nerves.Runtime.KV.UBootEnv do
     end
   end
 
-  def put(key, value) do
-    put(%{key => value})
-  end
-
+  @impl Nerves.Runtime.KV
   def put(%{} = kv) do
     case UBootEnv.read() do
       {:ok, current_kv} ->


### PR DESCRIPTION
This makes it a little more clear that the KV backend only supports
string keys and values.