### PR TITLE
Organize tests and add mount parser

### DIFF
--- a/test/nerves_runtime/init_test.exs
+++ b/test/nerves_runtime/init_test.exs
@@ -2,20 +2,38 @@ defmodule Nerves.Runtime.InitTest do
   use ExUnit.Case
   doctest Nerves.Runtime.Init
 
-  # alias Nerves.Runtime.Init
+  alias Nerves.Runtime.Init
 
-  # test "mounted?" do
-  #   mounts =
-  #     """
-  #     sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
-  #     proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
-  #     udev on /dev type devtmpfs (rw,nosuid,relatime,size=1979780k,nr_inodes=494945,mode=755)
-  #     devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000)
-  #     tmpfs on /run type tmpfs (ro,nosuid,noexec,relatime,size=400008k,mode=755)
-  #     /dev/sda1 on / type ext4 (rw,relatime,errors=remount-ro,data=ordered)
-  #     """
-  #   assert Init.mounted_state("/dev/sda1", "/", mounts) == :mounted
-  #   assert Init.mounted_state("tmpfs", "/run", mounts) == :mounted_with_error
-  #   assert Init.mounted_state("dsfds", "fggvef", mounts) == :unmounted
-  # end
+  test "usual mounted or unmounted results" do
+    mounts = """
+    /dev/root on / type squashfs (ro,relatime)
+    devtmpfs on /dev type devtmpfs (rw,nosuid,noexec,relatime,size=1024k,nr_inodes=57380,mode=755)
+    proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
+    sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
+    devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000)
+    tmpfs on /tmp type tmpfs (rw,nosuid,nodev,noexec,relatime,size=50924k)
+    tmpfs on /run type tmpfs (rw,nosuid,nodev,noexec,relatime,size=25464k,mode=755)
+    /dev/mmcblk0p1 on /mnt/boot type vfat (ro,nosuid,nodev,noexec,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro)
+    /dev/mmcblk0p4 on /root type f2fs (rw,lazytime,nodev,relatime,background_gc=on,discard,no_heap,inline_data,inline_dentry,flush_merge,extent_cache,mode=adaptive,active_logs=6,alloc_mode=reuse,fsync_mode=posix)
+    tmpfs on /sys/fs/cgroup type tmpfs (rw,nosuid,nodev,noexec,relatime,size=1024k,mode=755)
+    cpu on /sys/fs/cgroup/cpu type cgroup (rw,nosuid,nodev,noexec,relatime,cpu)
+    memory on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
+    pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
+    """
+
+    assert :mounted == Init.parse_mount_state("/dev/mmcblk0p4", "/root", mounts)
+
+    assert :unmounted == Init.parse_mount_state("/dev/mmcblk0p3", "/root", mounts)
+  end
+
+  test "mounted read only when should be read-write" do
+    mounts = """
+    /dev/root on / type squashfs (ro,relatime)
+    /dev/mmcblk0p1 on /mnt/boot type vfat (ro,nosuid,nodev,noexec,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro)
+    /dev/mmcblk0p4 on /root type f2fs (ro,nodev,relatime)
+    """
+
+    assert :mounted_with_error ==
+             Init.parse_mount_state("/dev/mmcblk0p4", "/root", mounts)
+  end
 end

--- a/test/nerves_runtime/init_test.exs
+++ b/test/nerves_runtime/init_test.exs
@@ -1,4 +1,4 @@
-defmodule InitTest do
+defmodule Nerves.Runtime.InitTest do
   use ExUnit.Case
   doctest Nerves.Runtime.Init
 

--- a/test/nerves_runtime/kv_test.exs
+++ b/test/nerves_runtime/kv_test.exs
@@ -1,4 +1,4 @@
-defmodule KVTest do
+defmodule Nerves.Runtime.KVTest do
   use ExUnit.Case, async: false
   doctest Nerves.Runtime.KV
 

--- a/test/nerves_runtime/log/kmsg_parser_test.exs
+++ b/test/nerves_runtime/log/kmsg_parser_test.exs
@@ -1,4 +1,4 @@
-defmodule KmsgParserTest do
+defmodule Nerves.Runtime.Log.KmsgParserTest do
   use ExUnit.Case
 
   alias Nerves.Runtime.Log.KmsgParser

--- a/test/nerves_runtime/log/syslog_parser_test.exs
+++ b/test/nerves_runtime/log/syslog_parser_test.exs
@@ -1,4 +1,4 @@
-defmodule SyslogParserTest do
+defmodule Nerves.Runtime.Log.SyslogParserTest do
   use ExUnit.Case
   doctest Nerves.Runtime.Log.SyslogParser
 


### PR DESCRIPTION
The mount output parsing code had been tested at one time, but was commented
out. This adds the tests and breaks out the pure functional part to avoid
calling the mount command.
