### PR TITLE
Reduce Makefile prints and protect against make clean accidents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # Makefile targets:
 #
-# all/install   build and install the NIF
+# all/install   build and install the port binaries
 # clean         clean build products and intermediates
 #
 # Variables to override:
@@ -74,9 +74,11 @@ all: install
 install: $(BUILD) $(DEFAULT_TARGETS)
 
 $(BUILD)/%.o: src/%.c
+	@echo " CC $(notdir $@)"
 	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<
 
 $(PREFIX)/nerves_runtime: $(BUILD)/nerves_runtime.o $(BUILD)/uevent.o $(BUILD)/kmsg_tailer.o
+	@echo " LD $(notdir $@)"
 	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
 	$(call update_perms, $@)
 
@@ -87,3 +89,6 @@ clean:
 	$(RM) $(PREFIX)/nerves_runtime $(BUILD)/*.o
 
 .PHONY: all clean calling_from_make install
+
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:

--- a/Makefile
+++ b/Makefile
@@ -85,10 +85,13 @@ $(PREFIX)/nerves_runtime: $(BUILD)/nerves_runtime.o $(BUILD)/uevent.o $(BUILD)/k
 $(PREFIX) $(BUILD):
 	mkdir -p $@
 
-clean:
+mix_clean:
 	$(RM) $(PREFIX)/nerves_runtime $(BUILD)/*.o
 
-.PHONY: all clean calling_from_make install
+clean:
+	mix clean
+
+.PHONY: all clean mix_clean calling_from_make install
 
 # Don't echo commands unless the caller exports "V=1"
 ${V}.SILENT:

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Nerves.Runtime.MixProject do
       build_embedded: true,
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
-      make_clean: ["clean"],
+      make_clean: ["mix_clean"],
       make_error_message: """
       If the error message above says that libmnl.h can't be found, then the
       fix is to install libmnl. For example, run `apt install libmnl-dev` on


### PR DESCRIPTION
- Reduce Makefile/gcc prints to clean build output
- Rename clean Makefile target to prevent accidents
