### PR TITLE
Support U-Boot bootcount/upgrade_available

### DIFF
--- a/lib/nerves_runtime.ex
+++ b/lib/nerves_runtime.ex
@@ -110,7 +110,12 @@ defmodule Nerves.Runtime do
   """
   @spec validate_firmware() :: :ok
   def validate_firmware() do
-    KV.put("nerves_fw_validated", "1")
+    # If using U-Boot's bootcount feature, set those variables as well
+    if KV.get("upgrade_available") do
+      KV.put(%{"upgrade_available" => "0", "bootcount" => "0", "nerves_fw_validated" => "1"})
+    else
+      KV.put("nerves_fw_validated", "1")
+    end
   end
 
   @doc """

--- a/test/nerves_runtime_test.exs
+++ b/test/nerves_runtime_test.exs
@@ -1,6 +1,8 @@
 defmodule NervesRuntimeTest do
   use ExUnit.Case
 
+  alias Nerves.Runtime.KV
+
   test "serial_number returns boardid result" do
     Application.put_env(:nerves_runtime, :boardid_path, Path.join(fixture_path(), "boardid"))
     assert Nerves.Runtime.serial_number() == "123456789"
@@ -18,11 +20,31 @@ defmodule NervesRuntimeTest do
   end
 
   test "firmware can be validated" do
+    KV.put(%{"upgrade_available" => nil, "bootcount" => nil, "nerves_fw_validated" => "0"})
     refute Nerves.Runtime.firmware_valid?()
 
     Nerves.Runtime.validate_firmware()
 
     assert Nerves.Runtime.firmware_valid?()
+    assert KV.get("nerves_fw_validated") == "1"
+
+    # Make sure that the U-Boot bootcount variables aren't set if they're not being used
+    assert KV.get("upgrade_available") == nil
+    assert KV.get("bootcount") == nil
+  end
+
+  test "firmware validation using U-Boot bootcount" do
+    KV.put(%{"upgrade_available" => "1", "bootcount" => "1", "nerves_fw_validated" => nil})
+    refute Nerves.Runtime.firmware_valid?()
+
+    Nerves.Runtime.validate_firmware()
+
+    assert Nerves.Runtime.firmware_valid?()
+    assert KV.get("upgrade_available") == "0"
+    assert KV.get("bootcount") == "0"
+
+    # nerves_fw_validated is set since some code in the wild still expects it
+    assert KV.get("nerves_fw_validated") == "1"
   end
 
   defp fixture_path() do


### PR DESCRIPTION
U-Boot supports running alternative boot commands if the main one fails
too many times. This can be used for trying out firmware updates and has
a couple advantages: 1. It's easier to talk to people who use U-Boot,
but not Nerves, 2. You can set a new firmware to be tried more than once
before reverting, and 3. The U-Boot script is simpler. The second reason
is interesting if aspects of validating a firmware image are out of your
control and it's better to try it a few times "just in case".

To use this feature, you need to update your U-Boot scripts and make
sure that the bootcount feature is enabled. The fwup script also needs
to be adjusted to set "upgrade_available" and "bootcount".

This change has no effect if you're not using the U-Boot "bootcount"
feature.
