### PR TITLE
Add force flag to mkfs.f2fs

### DIFF
--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -139,7 +139,7 @@ defmodule Nerves.Runtime.Init do
   defp format_if_unmounted(s), do: s
 
   defp mkfs("f2fs", devpath) do
-    check_cmd("mkfs.f2fs", ["#{devpath}"], :info)
+    check_cmd("mkfs.f2fs", ["-f", "#{devpath}"], :info)
   end
 
   defp mkfs(fstype, devpath) do


### PR DESCRIPTION
Match other `mkfs` commands and pass force flag to recreate partition if not mountable.

Looks like I missed this when adding the original `mkfs.f2fs` support.