### PR TITLE
Change firmware_valid? to be valid when not used

### DIFF
--- a/test/nerves_runtime_test.exs
+++ b/test/nerves_runtime_test.exs
@@ -47,6 +47,11 @@ defmodule NervesRuntimeTest do
     assert KV.get("nerves_fw_validated") == "1"
   end
 
+  test "firmware valid when not using firmware validity" do
+    KV.put(%{"nerves_fw_validated" => nil})
+    assert Nerves.Runtime.firmware_valid?()
+  end
+
   defp fixture_path() do
     Path.expand("test/fixture")
   end


### PR DESCRIPTION
If you think real hard when the firmware validity feature isn't used,
the firmware is implicitly valid. I.e., a reboot keeps the firmware
rather than reverting.

This changes the function to return `true` when it's not valid.

The immediate effect of this is that Raspberry Pi's which don't
auto-revert back on bad firmware will report `true` now.
