### PR TITLE
Extract mount parser to improve test

### DIFF
--- a/lib/nerves_runtime/mount_parser.ex
+++ b/lib/nerves_runtime/mount_parser.ex
@@ -1,0 +1,33 @@
+defmodule Nerves.Runtime.MountParser do
+  @moduledoc false
+
+  @typedoc false
+  @type mounts() :: %{String.t() => %{device: String.t(), type: String.t(), flags: [String.t()]}}
+
+  @doc false
+  @spec parse(String.t()) :: mounts()
+  def parse(mount_output) do
+    mount_output
+    |> String.split("\n")
+    |> Enum.reduce(%{}, &parse_line/2)
+  end
+
+  defp parse_line(line, mounts) do
+    case String.split(line) do
+      [device, "on", target, "type", type, flags_text | _] ->
+        flags = parse_flags(flags_text)
+        Map.put(mounts, target, %{device: device, type: type, flags: flags})
+
+      _ ->
+        # Ignore unknown mount strings
+        mounts
+    end
+  end
+
+  defp parse_flags(flags_text) do
+    flags_text
+    |> String.trim_leading("(")
+    |> String.trim_trailing(")")
+    |> String.split(",")
+  end
+end

--- a/test/nerves_runtime/init_test.exs
+++ b/test/nerves_runtime/init_test.exs
@@ -7,18 +7,7 @@ defmodule Nerves.Runtime.InitTest do
   test "usual mounted or unmounted results" do
     mounts = """
     /dev/root on / type squashfs (ro,relatime)
-    devtmpfs on /dev type devtmpfs (rw,nosuid,noexec,relatime,size=1024k,nr_inodes=57380,mode=755)
-    proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
-    sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
-    devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000)
-    tmpfs on /tmp type tmpfs (rw,nosuid,nodev,noexec,relatime,size=50924k)
-    tmpfs on /run type tmpfs (rw,nosuid,nodev,noexec,relatime,size=25464k,mode=755)
-    /dev/mmcblk0p1 on /mnt/boot type vfat (ro,nosuid,nodev,noexec,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro)
-    /dev/mmcblk0p4 on /root type f2fs (rw,lazytime,nodev,relatime,background_gc=on,discard,no_heap,inline_data,inline_dentry,flush_merge,extent_cache,mode=adaptive,active_logs=6,alloc_mode=reuse,fsync_mode=posix)
-    tmpfs on /sys/fs/cgroup type tmpfs (rw,nosuid,nodev,noexec,relatime,size=1024k,mode=755)
-    cpu on /sys/fs/cgroup/cpu type cgroup (rw,nosuid,nodev,noexec,relatime,cpu)
-    memory on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
-    pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
+    /dev/mmcblk0p4 on /root type f2fs (rw,nodev,relatime,background_gc=on,discard,no_heap,inline_data,flush_merge,extent_cache,mode=adaptive,active_logs=6,fsync_mode=posix)
     """
 
     assert :mounted == Init.parse_mount_state("/dev/mmcblk0p4", "/root", mounts)
@@ -28,8 +17,6 @@ defmodule Nerves.Runtime.InitTest do
 
   test "mounted read only when should be read-write" do
     mounts = """
-    /dev/root on / type squashfs (ro,relatime)
-    /dev/mmcblk0p1 on /mnt/boot type vfat (ro,nosuid,nodev,noexec,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro)
     /dev/mmcblk0p4 on /root type f2fs (ro,nodev,relatime)
     """
 

--- a/test/nerves_runtime/mount_parser_test.exs
+++ b/test/nerves_runtime/mount_parser_test.exs
@@ -1,0 +1,122 @@
+defmodule Nerves.Runtime.MountParserTest do
+  use ExUnit.Case
+
+  alias Nerves.Runtime.MountParser
+
+  test "parses example mount output" do
+    mount_output = """
+    /dev/root on / type squashfs (ro,relatime)
+    devtmpfs on /dev type devtmpfs (rw,nosuid,noexec,relatime,size=1024k,nr_inodes=57380,mode=755)
+    proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
+    sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
+    devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000)
+    tmpfs on /tmp type tmpfs (rw,nosuid,nodev,noexec,relatime,size=50924k)
+    tmpfs on /run type tmpfs (rw,nosuid,nodev,noexec,relatime,size=25464k,mode=755)
+    /dev/mmcblk0p1 on /mnt/boot type vfat (ro,nosuid,nodev,noexec,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,errors=remount-ro)
+    /dev/mmcblk0p4 on /root type f2fs (rw,lazytime,nodev,relatime,background_gc=on,discard,no_heap,inline_data,inline_dentry,flush_merge,extent_cache,mode=adaptive,active_logs=6,alloc_mode=reuse,fsync_mode=posix)
+    tmpfs on /sys/fs/cgroup type tmpfs (rw,nosuid,nodev,noexec,relatime,size=1024k,mode=755)
+    cpu on /sys/fs/cgroup/cpu type cgroup (rw,nosuid,nodev,noexec,relatime,cpu)
+    memory on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
+    pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
+    """
+
+    expected = %{
+      "/" => %{device: "/dev/root", type: "squashfs", flags: ["ro", "relatime"]},
+      "/dev" => %{
+        device: "devtmpfs",
+        type: "devtmpfs",
+        flags: ["rw", "nosuid", "noexec", "relatime", "size=1024k", "nr_inodes=57380", "mode=755"]
+      },
+      "/proc" => %{
+        device: "proc",
+        type: "proc",
+        flags: ["rw", "nosuid", "nodev", "noexec", "relatime"]
+      },
+      "/sys" => %{
+        device: "sysfs",
+        type: "sysfs",
+        flags: ["rw", "nosuid", "nodev", "noexec", "relatime"]
+      },
+      "/dev/pts" => %{
+        device: "devpts",
+        type: "devpts",
+        flags: ["rw", "nosuid", "noexec", "relatime", "gid=5", "mode=620", "ptmxmode=000"]
+      },
+      "/tmp" => %{
+        device: "tmpfs",
+        type: "tmpfs",
+        flags: ["rw", "nosuid", "nodev", "noexec", "relatime", "size=50924k"]
+      },
+      "/run" => %{
+        device: "tmpfs",
+        type: "tmpfs",
+        flags: ["rw", "nosuid", "nodev", "noexec", "relatime", "size=25464k", "mode=755"]
+      },
+      "/mnt/boot" => %{
+        device: "/dev/mmcblk0p1",
+        type: "vfat",
+        flags: [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "fmask=0022",
+          "dmask=0022",
+          "codepage=437",
+          "iocharset=iso8859-1",
+          "shortname=mixed",
+          "errors=remount-ro"
+        ]
+      },
+      "/root" => %{
+        device: "/dev/mmcblk0p4",
+        type: "f2fs",
+        flags: [
+          "rw",
+          "lazytime",
+          "nodev",
+          "relatime",
+          "background_gc=on",
+          "discard",
+          "no_heap",
+          "inline_data",
+          "inline_dentry",
+          "flush_merge",
+          "extent_cache",
+          "mode=adaptive",
+          "active_logs=6",
+          "alloc_mode=reuse",
+          "fsync_mode=posix"
+        ]
+      },
+      "/sys/fs/cgroup" => %{
+        device: "tmpfs",
+        type: "tmpfs",
+        flags: ["rw", "nosuid", "nodev", "noexec", "relatime", "size=1024k", "mode=755"]
+      },
+      "/sys/fs/cgroup/cpu" => %{
+        device: "cpu",
+        type: "cgroup",
+        flags: ["rw", "nosuid", "nodev", "noexec", "relatime", "cpu"]
+      },
+      "/sys/fs/cgroup/memory" => %{
+        device: "memory",
+        type: "cgroup",
+        flags: ["rw", "nosuid", "nodev", "noexec", "relatime", "memory"]
+      },
+      "/sys/fs/pstore" => %{
+        device: "pstore",
+        type: "pstore",
+        flags: ["rw", "nosuid", "nodev", "noexec", "relatime"]
+      }
+    }
+
+    assert expected == MountParser.parse(mount_output)
+  end
+
+  test "ignores bad mount output" do
+    assert %{} == MountParser.parse("This shouldn't happen")
+    assert %{} == MountParser.parse("")
+  end
+end


### PR DESCRIPTION
The purpose of this is to make it more obvious that the mount output
parser works. There were some assumptions in the code that looked like
they'd raise on unexpected output and this should be more whitespace
tolerant if that ever becomes an issue.
