### PR TITLE
Exit the init process when done

### DIFF
--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -48,7 +48,11 @@ defmodule Nerves.Runtime.Init do
   @impl GenServer
   def init(_args) do
     init_application_partition()
-    {:ok, %{}}
+
+    # This GenServer is only used as a hook to initialize the application data
+    # partition after the logging GenServers get started. It doesn't do
+    # anything afterwards, so exit the process.
+    :ignore
   end
 
   @spec init_application_partition :: :mounted | :mounted_with_error | :noop | :unmounted


### PR DESCRIPTION
There's no need to keep it around since it doesn't do anything after the
application data partition is created.
