### PR TITLE
Support OTP 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,11 @@ defaults: &defaults
   working_directory: ~/repo
 
 jobs:
-  build_elixir_1_13_otp_24:
+  build_elixir_1_13_otp_25:
     docker:
-      - image: erlang:24.2
+      - image: erlang:25.0
         environment:
-          ELIXIR_VERSION: 1.13.1-otp-24
+          ELIXIR_VERSION: 1.13.4-otp-25
           LC_ALL: C.UTF-8
           SUDO: true
     <<: *defaults
@@ -55,9 +55,25 @@ jobs:
             - _build
             - deps
 
+  build_elixir_1_13_otp_24:
+    docker:
+      - image: erlang:24.3.4
+        environment:
+          ELIXIR_VERSION: 1.13.4-otp-24
+          LC_ALL: C.UTF-8
+          SUDO: true
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_system_deps
+      - <<: *install_elixir
+      - <<: *install_hex
+      - run: mix deps.get
+      - run: mix test
+
   build_elixir_1_12_otp_24:
     docker:
-      - image: erlang:24.1
+      - image: erlang:24.3.4
         environment:
           ELIXIR_VERSION: 1.12.3-otp-24
           LC_ALL: C.UTF-8
@@ -73,7 +89,7 @@ jobs:
 
   build_elixir_1_11_otp_23:
     docker:
-      - image: erlang:23.3
+      - image: erlang:23.3.4.13
         environment:
           ELIXIR_VERSION: 1.11.4-otp-23
           LC_ALL: C.UTF-8
@@ -123,6 +139,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_13_otp_25
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23

--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,7 @@ defmodule Nerves.Runtime.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs]
+      flags: [:missing_return, :extra_return, :unmatched_returns, :error_handling, :underspecs]
     ]
   end
 


### PR DESCRIPTION
* remove deprecated `:race_conditions` dialyzer option
* Add new `:missing_return` and `:extra_return` dialyzer options
* Update Elixir/Erlang CI versions