### PR TITLE
Update .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,113 +1,60 @@
-version: 2
+version: 2.1
 
-install_elixir: &install_elixir
-  run:
-    name: Install Elixir
-    command: |
-      wget https://repo.hex.pm/builds/elixir/v$ELIXIR_VERSION.zip
-      unzip -d /usr/local/elixir v$ELIXIR_VERSION.zip
-      echo 'export PATH=/usr/local/elixir/bin:$PATH' >> $BASH_ENV
-
-install_hex: &install_hex
-  run:
-    name: Install hex
-    command: |
-      mix local.hex --force
-
-install_system_deps: &install_system_deps
-  run:
-    name: Install system dependencies
-    command: |
-      apt update
-      apt install -y unzip astyle libmnl-dev
-
-defaults: &defaults
-  working_directory: ~/repo
+latest: &latest
+  pattern: "^1.13.4-erlang-25.*$"
 
 jobs:
-  build_elixir_1_13_otp_25:
+  build-test:
+    parameters:
+      tag:
+        type: string
     docker:
-      - image: erlang:25.0
-        environment:
-          ELIXIR_VERSION: 1.13.4-otp-25
-          LC_ALL: C.UTF-8
-          SUDO: true
-    <<: *defaults
+      - image: hexpm/elixir:<< parameters.tag >>
+    working_directory: ~/repo
+    environment:
+      LC_ALL: C.UTF-8
     steps:
+      - run:
+          name: Install system dependencies
+          command: apk add --no-cache build-base git unzip astyle libmnl-dev
       - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
-      - <<: *install_hex
+      - run:
+          name: Install hex and rebar
+          command: |
+            mix local.hex --force
+            mix local.rebar --force
       - restore_cache:
           keys:
-            - v1-mix-cache-{{ checksum "mix.lock" }}
+            - v1-mix-cache-<< parameters.tag >>-{{ checksum "mix.lock" }}
       - run: mix deps.get
-      - run: mix format --check-formatted
-      - run: mix deps.unlock --check-unused
-      - run: mix docs
-      - run: mix hex.build
       - run: mix test
-      - run: mix credo -a
-      - run: mix dialyzer
+      - when:
+          condition:
+            matches: { <<: *latest, value: << parameters.tag >> }
+          steps:
+            - run: mix format --check-formatted
+            - run: mix deps.unlock --check-unused
+            - run: mix docs
+            - run: mix hex.build
+            - run: mix credo -a --strict
+            - run: mix dialyzer
       - save_cache:
-          key: v1-mix-cache-{{ checksum "mix.lock" }}
+          key: v1-mix-cache-<< parameters.tag >>-{{ checksum "mix.lock" }}
           paths:
             - _build
             - deps
 
-  build_elixir_1_13_otp_24:
-    docker:
-      - image: erlang:24.3.4
-        environment:
-          ELIXIR_VERSION: 1.13.4-otp-24
-          LC_ALL: C.UTF-8
-          SUDO: true
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
-      - <<: *install_hex
-      - run: mix deps.get
-      - run: mix test
-
-  build_elixir_1_12_otp_24:
-    docker:
-      - image: erlang:24.3.4
-        environment:
-          ELIXIR_VERSION: 1.12.3-otp-24
-          LC_ALL: C.UTF-8
-          SUDO: true
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
-      - <<: *install_hex
-      - run: mix deps.get
-      - run: mix test
-
-  build_elixir_1_11_otp_23:
-    docker:
-      - image: erlang:23.3.4.13
-        environment:
-          ELIXIR_VERSION: 1.11.4-otp-23
-          LC_ALL: C.UTF-8
-          SUDO: true
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
-      - <<: *install_hex
-      - run: mix deps.get
-      - run: mix test
-
 workflows:
-  version: 2
-  build_test:
+  checks:
     jobs:
-      - build_elixir_1_13_otp_25
-      - build_elixir_1_13_otp_24
-      - build_elixir_1_12_otp_24
-      - build_elixir_1_11_otp_23
+      - build-test:
+          name: << matrix.tag >>
+          matrix:
+            parameters:
+              tag: [
+                1.13.4-erlang-25.0.1-alpine-3.15.4,
+                1.13.4-erlang-24.3.4-alpine-3.15.3,
+                1.12.3-erlang-24.3.4-alpine-3.15.3,
+                1.11.4-erlang-24.3.4-alpine-3.15.3,
+                1.11.4-erlang-23.3.4.13-alpine-3.15.3
+              ]

--- a/.circleci/md-style.rb
+++ b/.circleci/md-style.rb
@@ -1,4 +1,0 @@
-all
-exclude_rule 'MD026'
-rule 'MD029', :style => 'ordered'
-rule 'MD013', :code_blocks => false, :tables => false


### PR DESCRIPTION
This brings in a few CI updates to hopefully make it easier to adjust and
use in the future. This matches what is currently being used in `property_tables`

Adding a new elixir/OTP version is now a simple tag addition to the matrix.
To mark a new tag as the latest, you only need to adjust the `&latest` anchor