### PR TITLE
Centralize application configuration defaults

### DIFF
--- a/lib/nerves_runtime.ex
+++ b/lib/nerves_runtime.ex
@@ -5,9 +5,6 @@ defmodule Nerves.Runtime do
   alias Nerves.Runtime.{KV, OutputLogger, Power}
   require Logger
 
-  # These are provided by all official Nerves system images
-  @revert_fw_path "/usr/share/fwup/revert.fw"
-
   # Capture the target that this was built for
   @mix_target Mix.target()
 
@@ -56,8 +53,10 @@ defmodule Nerves.Runtime do
   def revert(opts \\ []) do
     reboot? = if opts[:reboot] != nil, do: opts[:reboot], else: true
 
-    if File.exists?(@revert_fw_path) do
-      {_, 0} = cmd("fwup", [@revert_fw_path, "-t", "revert", "-d", "/dev/rootdisk0"], :info)
+    revert_fw_path = Application.get_env(:nerves_runtime, :revert_fw_path)
+
+    if File.exists?(revert_fw_path) do
+      {_, 0} = cmd("fwup", [revert_fw_path, "-t", "revert", "-d", "/dev/rootdisk0"], :info)
 
       if reboot? do
         reboot()
@@ -65,7 +64,7 @@ defmodule Nerves.Runtime do
         :ok
       end
     else
-      {:error, "Unable to locate revert firmware at path: #{@revert_fw_path}"}
+      {:error, "Unable to locate revert firmware at path: #{revert_fw_path}"}
     end
   end
 

--- a/lib/nerves_runtime.ex
+++ b/lib/nerves_runtime.ex
@@ -7,7 +7,6 @@ defmodule Nerves.Runtime do
 
   # These are provided by all official Nerves system images
   @revert_fw_path "/usr/share/fwup/revert.fw"
-  @boardid_path "/usr/bin/boardid"
 
   # Capture the target that this was built for
   @mix_target Mix.target()
@@ -90,7 +89,7 @@ defmodule Nerves.Runtime do
   """
   @spec serial_number() :: String.t()
   def serial_number() do
-    boardid_path = Application.get_env(:nerves_runtime, :boardid_path, @boardid_path)
+    boardid_path = Application.get_env(:nerves_runtime, :boardid_path)
     {serial, 0} = System.cmd(boardid_path, [])
     String.trim(serial)
   catch

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,9 @@ defmodule Nerves.Runtime.MixProject do
 
   def application do
     [
+      env: [
+        boardid: "/usr/bin/boardid"
+      ],
       extra_applications: [:logger],
       mod: {Nerves.Runtime.Application, []}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,9 @@ defmodule Nerves.Runtime.MixProject do
   def application do
     [
       env: [
-        boardid: "/usr/bin/boardid"
+        # These are provided by all official Nerves system images
+        boardid: "/usr/bin/boardid",
+        revert_fw_path: "/usr/share/fwup/revert.fw"
       ],
       extra_applications: [:logger],
       mod: {Nerves.Runtime.Application, []}


### PR DESCRIPTION
This starts the process of centralizing application configuration so that it's
easier to see what all is configurable by looking at the code. It's also
important to have the application config documented, but I'm going to tackle
that in a future PR when the KV store update is in. I'm keeping the KV store
update separate since it was a bigger change.

- Move boardid config default to mix.exs
- Make revert_fw_path configurable
