### PR TITLE
Fix supporting backwards compatible `Nerves.Runtime.KV.Mock`

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,8 @@ information from the `Nerves.Runtime.KV` can mock the contents with the included
 `Nerves.Runtime.KVBackend.InMemory` module through the Application config:
 
 ```elixir
-config :nerves_runtime, Nerves.Runtime.KVBackend.InMemory, %{"key" => "value"}
+config :nerves_runtime,
+  kv_backend: {Nerves.Runtime.KVBackend.InMemory, contents: %{"key" => "value"}}
 ```
 
 You can also create your own module based on the `Nerves.Runtime.KVBackend`

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -293,7 +293,8 @@ defmodule Nerves.Runtime.KV do
 
       _ ->
         # Handle Nerves.Runtime v0.12.0 and earlier way
-        initial_contents = options[:modules][Nerves.Runtime.KV.Mock]
+        initial_contents =
+          options[:modules][Nerves.Runtime.KV.Mock] || options[Nerves.Runtime.KV.Mock]
 
         Logger.error(
           "Using Nerves.Runtime.KV.Mock is deprecated. Use `config :nerves_runtime, kv_backend: {Nerves.Runtime.KVBackend.InMemory, contents: #{inspect(initial_contents)}}`"

--- a/test/nerves_runtime/kv_test.exs
+++ b/test/nerves_runtime/kv_test.exs
@@ -106,6 +106,14 @@ defmodule Nerves.Runtime.KVTest do
   end
 
   @tag kv_options: [{:modules, [{Nerves.Runtime.KV.Mock, %{"key" => "value"}}]}]
+  test "old modules configuration" do
+    assert KV.get("key") == "value"
+
+    assert :ok = KV.put("test_key", "test_value")
+    assert KV.get("test_key") == "test_value"
+  end
+
+  @tag kv_options: [{Nerves.Runtime.KV.Mock, %{"key" => "value"}}]
   test "old configuration" do
     assert KV.get("key") == "value"
 


### PR DESCRIPTION
Turns out we used to support just specifying `Nerves.Runtime.KV.Mock` as
a key in the `:nerves_runtime` application config along with the `:modules`
specification

This adds that backwards compatibility back in