### PR TITLE
Fix mismatched `boardid_path` application config option

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Nerves.Runtime.MixProject do
   def application do
     [
       env: [
-        boardid: "/usr/bin/boardid",
+        boardid_path: "/usr/bin/boardid",
         revert_fw_path: "/usr/share/fwup/revert.fw",
         kv_backend: kv_backend(Mix.target())
       ],


### PR DESCRIPTION
The default in `mix.exs` does not match the expected value of `boardid_path`
https://github.com/nerves-project/nerves_runtime/blob/main/lib/nerves_runtime.ex#L91