### PR TITLE
Support Nerves Heart 2.0 guarded reboot and handshake

### DIFF
--- a/lib/nerves_runtime.ex
+++ b/lib/nerves_runtime.ex
@@ -23,7 +23,7 @@ defmodule Nerves.Runtime do
   the system will be hard rebooted.
   """
   @spec reboot() :: no_return()
-  def reboot(), do: Power.run_command("reboot")
+  defdelegate reboot(), to: Power
 
   @doc """
   Power off the device.
@@ -33,7 +33,7 @@ defmodule Nerves.Runtime do
   the system will be hard rebooted.
   """
   @spec poweroff() :: no_return()
-  def poweroff(), do: Power.run_command("poweroff")
+  defdelegate poweroff(), to: Power
 
   @doc """
   Halt the device (meaning hang, not power off, nor reboot).
@@ -42,7 +42,7 @@ defmodule Nerves.Runtime do
   rebooting the device if `erlinit.config` settings allow reboot on exit.
   """
   @spec halt() :: no_return()
-  def halt(), do: Power.run_command("halt")
+  defdelegate halt(), to: Power
 
   @doc """
   Revert the device to running the previous firmware.

--- a/lib/nerves_runtime/power.ex
+++ b/lib/nerves_runtime/power.ex
@@ -11,12 +11,50 @@ defmodule Nerves.Runtime.Power do
   #    poweroff.
 
   use GenServer
+
+  alias Nerves.Runtime.Heart
+
   require Logger
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(options) do
     GenServer.start_link(__MODULE__, options, name: __MODULE__)
   end
+
+  # Delegated from Nerves.Runtime
+  @doc false
+  @spec reboot() :: no_return()
+  def reboot() do
+    case Heart.guarded_reboot() do
+      :ok ->
+        :init.stop()
+
+      _ ->
+        run_command("reboot")
+    end
+  catch
+    _, _ -> :erlang.halt()
+  end
+
+  # Delegated from Nerves.Runtime
+  @doc false
+  @spec poweroff() :: no_return()
+  def poweroff() do
+    case Heart.guarded_reboot() do
+      :ok ->
+        :init.stop()
+
+      _ ->
+        run_command("poweroff")
+    end
+  catch
+    _, _ -> :erlang.halt()
+  end
+
+  # Delegated from Nerves.Runtime
+  @doc false
+  @spec halt() :: no_return()
+  def halt(), do: run_command("halt")
 
   @doc """
   Run a power management command


### PR DESCRIPTION
If Nerves Heart 2.0 is available, then the reboot and poweroff functions
will go through it. This has two advantages:

1. If the system is messed up in such a way that cause OS processes to
   fail to start, a graceful reboot and poweroff may still work. The
   current way is to run Busybox poweroff and reboot.
2. Reboot and Poweroff now stop the hardware watchdog from being petted.
   This puts a hard limit on how long they can take.

The other addition is an `init_complete` call to protect the time
between boot and calling `:heart.set_callback/1`. The idea is that you
tell Nerves Heart 2.0 via configuration that it should expect an
initialization complete notification and how long to wait. If time
passes without the notification, Nerves Heart reboots the system since
something is wrong. You call this after calling `:heart.set_callback/1`
and then the callback that you supply takes over in checking whether
everything is ok. See docs for more details.
