### PR TITLE
Optimize `Nerves.Runtime.Heart.parse_cmd/1`

### DIFF
--- a/lib/nerves_runtime/heart.ex
+++ b/lib/nerves_runtime/heart.ex
@@ -168,13 +168,11 @@ defmodule Nerves.Runtime.Heart do
 
   def parse_cmd(cmd) when is_list(cmd) do
     result =
-      cmd
-      |> to_string()
-      |> String.split("\n")
-      |> Enum.map(&String.split(&1, "=", parts: 2))
-      |> Enum.map(&parse_attribute/1)
-      |> Enum.reject(&is_nil/1)
-      |> Map.new()
+      for kv_str <- String.split(to_string(cmd), "\n"),
+          kv = String.split(kv_str, "=", parts: 2),
+          parsed = parse_attribute(kv),
+          into: %{},
+          do: parsed
 
     {:ok, result}
   rescue


### PR DESCRIPTION
Reduces the number of loops through parsing the `:heart` status in an effort to reduce processing time on functions that might be time sensitive.

The is really the result of OCD after seeing so many Enum calls while testing the new release. It can be thrown out without feelings hurt, but I thought it was interesting

<details>
<summary>Benchmarks</summary>

```
Operating System: macOS
CPU Information: Apple M1 Pro
Number of Available Cores: 10
Available memory: 32 GB
Elixir 1.14.2
Erlang 25.1.1

Benchmark suite executing with the following configuration:
warmup: 1 s
time: 5 s
memory time: 2 s
reduction time: 2 s
parallel: 1
inputs: none specified
Estimated total run time: 30 s

Benchmarking for-comprehension ...
Benchmarking piped-Enums (old) ...
Benchmarking Stream ...

Name                           ips        average  deviation         median         99th %
for-comprehension         149.28 K        6.70 μs   ±330.04%        6.21 μs       12.88 μs
piped-Enums (old)         144.47 K        6.92 μs   ±351.26%        6.42 μs       13.13 μs
Stream                    132.79 K        7.53 μs   ±121.02%           7 μs       13.96 μs

Comparison: 
for-comprehension         149.28 K
piped-Enums (old)         144.47 K - 1.03x slower +0.22 μs
Stream                    132.79 K - 1.12x slower +0.83 μs

Memory usage statistics:

Name                      Memory usage
for-comprehension          5.98 KB
piped-Enums (old)          6.49 KB - 1.09x memory usage +0.52 KB
Stream                     7.99 KB - 1.34x memory usage +2.02 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name                      Reduction count
for-comprehension          8.32 K
piped-Enums (old)          8.25 K - 0.99x reduction count -0.07400 K
Stream                     8.48 K - 1.02x reduction count +0.157 K
```
</details>