### PR TITLE
Prevent poweroff from rebooting

### DIFF
--- a/lib/nerves_runtime/power.ex
+++ b/lib/nerves_runtime/power.ex
@@ -40,7 +40,7 @@ defmodule Nerves.Runtime.Power do
   @doc false
   @spec poweroff() :: no_return()
   def poweroff() do
-    case Heart.guarded_reboot() do
+    case Heart.guarded_poweroff() do
       :ok ->
         :init.stop()
 


### PR DESCRIPTION
This fixes an issue with the watchdog triggering when the system is supposed to power off.