### PR TITLE
Return more detailed errors on Heart problems

### DIFF
--- a/test/nerves_runtime/heart_test.exs
+++ b/test/nerves_runtime/heart_test.exs
@@ -124,13 +124,13 @@ defmodule Nerves.Runtime.HeartTest do
     end
 
     test "Erlang heart" do
-      assert :error = Heart.parse_cmd('')
-      assert :error = Heart.parse_cmd('reboot')
+      assert {:error, :not_nerves_heart} = Heart.parse_cmd('')
+      assert {:error, :parse_error} = Heart.parse_cmd('reboot')
     end
 
     test "parse errors" do
-      assert :error = Heart.parse_cmd('program_version=1.0')
-      assert :error = Heart.parse_cmd('reboot')
+      assert {:error, :parse_error} = Heart.parse_cmd('program_version=1.0')
+      assert {:error, :parse_error} = Heart.parse_cmd('reboot')
     end
   end
 end


### PR DESCRIPTION
The difference between heart not running, its queue being blocked and
other heart issues wasn't obvious, so add detail to the errors to make
it easier to see which path was taken.

This also cleans up the threading and versioning when issuing commands.
