### PR TITLE
Add helpers for the relatively new fwup ops.fw tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ filesystems uninitialized so that the format operation happens on the first
 boot. This means that the first boot takes slightly longer than subsequent
 boots.
 
-Note that a common implementation of "reset to factory defaults" is to purposely
-corrupt the application partition and reboot.
+A common implementation of "reset to factory defaults" is to purposely erase
+(corrupt) the application partition and reboot. See
+`Nerves.Runtime.FwupOps.factory_reset/1`.
 
 `nerves_runtime` uses firmware metadata to determine how to mount and initialize
 the application partition. The following variables are important:
@@ -165,6 +166,11 @@ iex> Nerves.Runtime.revert
 
 Running this command manually is useful in development. Production use requires
 more work to protect against faulty upgrades.
+
+Newer Nerves systems support preventing a revert. This is useful when you've
+loaded a version of firmware that is not meant to be used after it has been
+upgraded. This could be a factory test or an initial firmware that bootstraps
+encrypted firmware storage. See `Nerves.Runtime.FwupOps.prevent_revert/0`.
 
 ### Assisted firmware validation and automatic revert
 

--- a/lib/nerves_runtime/fwup_ops.ex
+++ b/lib/nerves_runtime/fwup_ops.ex
@@ -1,0 +1,123 @@
+defmodule Nerves.Runtime.FwupOps do
+  @moduledoc """
+  Convenience functions for /usr/share/fwup/ops.fw
+
+  The `/usr/share/fwup/ops.fw` is provided by the Nerves system for handling
+  some eMMC/MicroSD card operations. Look for `fwup-ops.conf` in the Nerves
+  system source tree for more details. It used to be called
+  `revert.fw`/`fwup-revert.conf` when it only handled reverting which firmware
+  image was active.
+  """
+
+  @old_revert_fw_path "/usr/share/fwup/revert.fw"
+  @ops_fw_path "/usr/share/fwup/ops.fw"
+
+  @typedoc """
+  General options for utilities
+
+  * `:reboot` - Call `Nerves.Runtime.reboot/0` after running (defaults to
+   `true` on destructive operations)
+  """
+  @type options :: [reboot: boolean()]
+
+  @doc """
+  Revert to the previous firmware
+
+  This invokes the "revert" task in the `ops.fw` and then reboots (unless told
+  otherwise).  The revert task switches the active firmware partition to the
+  opposite one so that future reboots use the previous firmware.
+  """
+  @spec revert(options()) :: :ok | {:error, reason :: any} | no_return()
+  def revert(opts \\ []) do
+    reboot? = if opts[:reboot] != nil, do: opts[:reboot], else: true
+
+    with :ok <- run_fwup("revert") do
+      if reboot? do
+        Nerves.Runtime.reboot()
+      else
+        :ok
+      end
+    end
+  end
+
+  @doc """
+  Make it impossible to revert to the other partition
+
+  This wipes the opposite firmware partition and clears out metadata for it.
+  Attempts to revert will fail. This is useful if loading a special firmware
+  temporarily that shouldn't be used again even accidentally.
+  """
+  @spec prevent_revert() :: :ok | {:error, reason :: any}
+  def prevent_revert() do
+    run_fwup("prevent-revert")
+  end
+
+  @doc """
+  Validate the current partition
+
+  For Nerves systems that support automatic rollback of firmware versions, this
+  marks the partition as good so that it will continue to be used on future
+  boots.
+
+  Call `Nerves.Runtime.validate_firmware/0` instead.
+  """
+  @spec validate() :: :ok | {:error, reason :: any}
+  def validate() do
+    run_fwup("validate")
+  end
+
+  @doc """
+  Reset the application data partition to its original state
+
+  This clears out the application data partition at a low level so that it will
+  be reformatted on the next boot. If all application settings are stored on
+  the partition, then this will be like a factory reset. Be aware that many
+  settings are stored on the application data partition including network
+  settings like WiFi SSIDs and passwords. Factory reset devices may not connect
+  to the network afterwards.
+  """
+  @spec factory_reset(options()) :: :ok | {:error, reason :: any}
+  def factory_reset(opts \\ []) do
+    reboot? = if opts[:reboot] != nil, do: opts[:reboot], else: true
+
+    with :ok <- run_fwup("factory-reset") do
+      if reboot? do
+        Nerves.Runtime.reboot()
+      else
+        :ok
+      end
+    end
+  end
+
+  defp run_fwup(task) do
+    with {:ok, ops_fw} <- ops_fw_path(),
+         {:ok, fwup} <- fwup_path() do
+      params = [ops_fw, "-t", task, "-d", "/dev/rootdisk0", "-q", "-U", "--enable-trim"]
+
+      case System.cmd(fwup, params) do
+        {_, 0} -> :ok
+        {result, _} -> {:error, result}
+      end
+    end
+  end
+
+  defp fwup_path() do
+    fwup_path = Application.get_env(:nerves_runtime, :fwup_path)
+
+    case System.find_executable(fwup_path) do
+      nil -> {:error, "Can't find fwup"}
+      path -> {:ok, path}
+    end
+  end
+
+  defp ops_fw_path() do
+    app_path = Application.get_env(:nerves_runtime, :revert_fw_path)
+
+    cond do
+      is_binary(app_path) and File.exists?(app_path) -> {:ok, app_path}
+      File.exists?(@ops_fw_path) -> {:ok, @ops_fw_path}
+      File.exists?(@old_revert_fw_path) -> {:ok, @old_revert_fw_path}
+      true -> {:error, "ops.fw or revert.fw not found in Nerves system"}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule Nerves.Runtime.MixProject do
     [
       env: [
         boardid_path: "/usr/bin/boardid",
+        fwup_path: "fwup",
         revert_fw_path: "/usr/share/fwup/revert.fw",
         kv_backend: kv_backend(Mix.target())
       ],

--- a/test/fixture/fwup
+++ b/test/fixture/fwup
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo -n "$*" > fwup-args
+
+exit 0

--- a/test/nerves_runtime/fwup_ops_test.exs
+++ b/test/nerves_runtime/fwup_ops_test.exs
@@ -1,0 +1,60 @@
+defmodule NervesRuntime.FwupOpsTest do
+  use ExUnit.Case
+
+  alias Nerves.Runtime.FwupOps
+
+  setup do
+    Application.put_env(:nerves_runtime, :fwup_path, fixture_path("fwup"))
+    Application.put_env(:nerves_runtime, :revert_fw_path, fixture_path("ops.fw"))
+
+    on_exit(fn -> File.rm("fwup-args") end)
+  end
+
+  test "revert" do
+    assert :ok = FwupOps.revert(reboot: false)
+
+    assert fwup_args() ==
+             "#{fixture_path("ops.fw")} -t revert -d /dev/rootdisk0 -q -U --enable-trim"
+  end
+
+  test "factory reset" do
+    assert :ok = FwupOps.factory_reset(reboot: false)
+
+    assert fwup_args() ==
+             "#{fixture_path("ops.fw")} -t factory-reset -d /dev/rootdisk0 -q -U --enable-trim"
+  end
+
+  test "validate" do
+    assert :ok = FwupOps.validate()
+
+    assert fwup_args() ==
+             "#{fixture_path("ops.fw")} -t validate -d /dev/rootdisk0 -q -U --enable-trim"
+  end
+
+  test "prevent_revert" do
+    assert :ok = FwupOps.prevent_revert()
+
+    assert fwup_args() ==
+             "#{fixture_path("ops.fw")} -t prevent-revert -d /dev/rootdisk0 -q -U --enable-trim"
+  end
+
+  test "missing ops.fw" do
+    Application.put_env(:nerves_runtime, :revert_fw_path, fixture_path("missing_ops.fw"))
+
+    assert {:error, _} = FwupOps.validate()
+  end
+
+  test "missing fwup" do
+    Application.put_env(:nerves_runtime, :fwup_path, "/does/not/exist/fwup")
+
+    assert {:error, _} = FwupOps.validate()
+  end
+
+  defp fwup_args() do
+    File.read!("fwup-args")
+  end
+
+  defp fixture_path(relative_path) do
+    Path.expand(relative_path, "test/fixture")
+  end
+end


### PR DESCRIPTION
This also improves error handling for Nerves.Runtime.revert/1 as a side
effect of it using almost all of the same code as the new helpers.

The new helpers aren't promoted to the Nerves.Runtime interface yet
since they haven't been released in the official Nerves systems.
