### PR TITLE
Add an infinite sleep when calling reboot

### DIFF
--- a/lib/nerves_runtime/power.ex
+++ b/lib/nerves_runtime/power.ex
@@ -29,6 +29,9 @@ defmodule Nerves.Runtime.Power do
       :ok ->
         :init.stop()
 
+        # :init.stop() isn't sleeping forever and returns in some cases
+        Process.sleep(:infinity)
+
       _ ->
         run_command("reboot")
     end


### PR DESCRIPTION
`:init.stop()` returns and it's not supposed to, this might be in newer OTPs only.