### PR TITLE
Sleep forever after a poweroff similar to rebooting

### DIFF
--- a/lib/nerves_runtime/power.ex
+++ b/lib/nerves_runtime/power.ex
@@ -29,7 +29,7 @@ defmodule Nerves.Runtime.Power do
       :ok ->
         :init.stop()
 
-        # :init.stop() isn't sleeping forever and returns in some cases
+        # Sleep forever since callers of this function don't expect it to return
         Process.sleep(:infinity)
 
       _ ->
@@ -46,6 +46,9 @@ defmodule Nerves.Runtime.Power do
     case Heart.guarded_poweroff() do
       :ok ->
         :init.stop()
+
+        # Sleep forever since callers of this function don't expect it to return
+        Process.sleep(:infinity)
 
       _ ->
         run_command("poweroff")


### PR DESCRIPTION
`:init.stop()` will return and callers don't expect this function to ever return. Also update the comment in reboot to be similar to the other sleep comments.