### PR TITLE
Simplify and further bulletproof poweroff error cases

### DIFF
--- a/lib/nerves_runtime/application.ex
+++ b/lib/nerves_runtime/application.ex
@@ -26,7 +26,6 @@ defmodule Nerves.Runtime.Application do
       [
         NervesLogging.KmsgTailer,
         NervesLogging.SyslogTailer,
-        Nerves.Runtime.Power,
         Nerves.Runtime.Init
       ]
     end

--- a/lib/nerves_runtime/power.ex
+++ b/lib/nerves_runtime/power.ex
@@ -1,104 +1,92 @@
 defmodule Nerves.Runtime.Power do
   @moduledoc false
 
-  # This GenServer handles the poweroff and reboot operations:
+  # This module handles the poweroff and reboot operations:
   #
-  # 1. It serializes calls to reboot and poweroff. First one wins if
-  #    multiple processes want reboot simultaneously.
-  # 2. It decouples the process that the reboot or poweroff sequence
-  #    happens in. This lets supervision trees go down midway through
-  #    the poweroff process without killing the process doing the
-  #    poweroff.
-
-  use GenServer
+  # It tries to bulletproof issues that can derail a reboot or poweroff sequence
+  # from completing. See comments in the code below for details. These have been
+  # seen in production.
 
   alias Nerves.Runtime.Heart
 
   require Logger
 
-  @spec start_link(keyword()) :: GenServer.on_start()
-  def start_link(options) do
-    GenServer.start_link(__MODULE__, options, name: __MODULE__)
-  end
+  @dialyzer {:no_return, run_command: 1}
+
+  @typep command() :: :reboot | :poweroff | :halt
+
+  # This is a worst case shutdown timeout. It shouldn't be hit unless shutdown
+  # functions take a surprisingly long time.
+  @timeout_before_halt :timer.minutes(10)
 
   # Delegated from Nerves.Runtime
   @doc false
   @spec reboot() :: no_return()
-  def reboot() do
-    case Heart.guarded_reboot() do
-      :ok ->
-        :init.stop()
-
-        # :init.stop() isn't sleeping forever and returns in some cases
-        Process.sleep(:infinity)
-
-      _ ->
-        run_command("reboot")
-    end
-  catch
-    _, _ -> :erlang.halt()
-  end
+  def reboot(), do: run_command(:reboot)
 
   # Delegated from Nerves.Runtime
   @doc false
   @spec poweroff() :: no_return()
-  def poweroff() do
-    case Heart.guarded_poweroff() do
-      :ok ->
-        :init.stop()
-
-      _ ->
-        run_command("poweroff")
-    end
-  catch
-    _, _ -> :erlang.halt()
-  end
+  def poweroff(), do: run_command(:poweroff)
 
   # Delegated from Nerves.Runtime
   @doc false
   @spec halt() :: no_return()
-  def halt(), do: run_command("halt")
+  def halt(), do: run_command(:halt)
 
-  @doc """
-  Run a power management command
+  # Run a power management command
+  #
+  # This function doesn't return since the system will power off or reboot
+  # shortly after it's called.
+  @spec run_command(command()) :: no_return
+  defp run_command(cmd) when is_atom(cmd) do
+    # Start the shutdown going in a process decoupled from this one, so if
+    # some process terminates this one (like a supervisor), the shutdown isn't half completed.
+    _ = spawn(fn -> do_run_command(cmd) end)
 
-  The only valid commands are `"reboot"`, `"poweroff"`, and `"halt"`. This is
-  NOT intended to be called directly. Call `Nerves.Runtime.reboot/0`, etc. instead.
-
-  This function doesn't return since the system will power off or reboot
-  shortly after it's called.
-  """
-  @spec run_command(String.t()) :: no_return()
-  def run_command(cmd) when is_binary(cmd) do
-    GenServer.cast(__MODULE__, cmd)
-
-    # Sleep forever since callers of this function don't expect it to return
-    Process.sleep(:infinity)
+    # Sleep so that the power management command can complete, but not forever
+    # just in case it never completes.
+    Process.sleep(@timeout_before_halt)
+  after
+    # If we get here, exit. Don't try to recover.
+    :erlang.halt()
   end
 
-  @impl GenServer
-  def init(_options) do
-    {:ok, nil}
-  end
-
-  @impl GenServer
-  @dialyzer {:nowarn_function, handle_cast: 2}
-  def handle_cast(cmd, _state) do
+  @spec do_run_command(command()) :: no_return
+  defp do_run_command(cmd) do
     Logger.info("#{__MODULE__} : device told to #{cmd}")
 
-    # Invoke the appropriate command to tell erlinit that a shutdown of the
-    # Erlang VM is imminent. Once this returns, the Erlang has about 10
-    # seconds to exit unless `--graceful-powerdown` is used in the
-    # `erlinit.config` to modify the timeout.
-    {_, 0} = Nerves.Runtime.cmd(cmd, [], :info)
+    # First try using Nerves Heart to use the watchdog to guard how long it
+    # takes to power off or reboot.
+    with {:error, _} <- guarded_command(cmd) do
+      # If that doesn't work, try invoking Busybox's reboot, shutdown, or halt
+      # programs to tell erlinit (PID 1) that a shutdown of the Erlang VM is
+      # imminent. Once this returns, Erlang has about 10 seconds to exit unless
+      # `--graceful-powerdown` is used in the `erlinit.config` to modify
+      # the timeout.
+
+      {_, 0} = Nerves.Runtime.cmd(busybox_command(cmd), [], :info)
+    end
 
     # Start a graceful shutdown
     :ok = :init.stop()
-    {:stop, :normal}
+
+    # Give it time, but don't wait forever.
+    Process.sleep(@timeout_before_halt)
+  catch
+    _, _ ->
+      # If any above raised an exception, log and then halt
+      Logger.info("#{__MODULE__} : Exception raised when trying to #{cmd}")
   after
-    # If anything unexpected happens, call :erlang.halt() to avoid getting
-    # stuck in a state where the application thinks it's done.
+    # If we get here, exit. Don't try to recover.
     :erlang.halt()
-    {:stop, :normal}
   end
+
+  defp guarded_command(:halt), do: {:error, :not_implemented}
+  defp guarded_command(:poweroff), do: Heart.guarded_poweroff()
+  defp guarded_command(:reboot), do: Heart.guarded_reboot()
+
+  defp busybox_command(:halt), do: "halt"
+  defp busybox_command(:poweroff), do: "poweroff"
+  defp busybox_command(:reboot), do: "reboot"
 end


### PR DESCRIPTION
This cleans up the poweroff code that got a little more complicated with
the guarded poweroff feature. There's no GenServer running and the code
to prevent multiple calls to power off simultanously has been removed
since that doesn't seem to be a big risk. The poweroff is still run in
an process that's not linked to the caller to avoid supervision tree
restarts from halting a poweroff.

This also fixes a bug where control was returned to the caller after an
`:init.stop/0`. The new way is to wait 10 minutes and then call
`:erlang.halt/0` as a last resort. The guarded reboot/poweroff should
kick in before this, though.
