### PR TITLE
Remount ext4 app partition read-only on error

### DIFF
--- a/lib/nerves_runtime/init.ex
+++ b/lib/nerves_runtime/init.ex
@@ -137,6 +137,18 @@ defmodule Nerves.Runtime.Init do
     check_cmd("mkfs.f2fs", ["-f", "#{devpath}"], :info)
   end
 
+  defp mkfs("ext4", devpath) do
+    # Remount read-only on errors. The default is to continue on error which
+    # partially fails with corruption errors when it fails. Remounting
+    # read-only is the previous behavior and seems slightly easier to deal
+    # with.
+    check_cmd(
+      "mkfs.ext4",
+      ["-e", "remount-ro", "-U", @app_partition_uuid, "-F", "#{devpath}"],
+      :info
+    )
+  end
+
   defp mkfs(fstype, devpath) do
     check_cmd("mkfs.#{fstype}", ["-U", @app_partition_uuid, "-F", "#{devpath}"], :info)
   end


### PR DESCRIPTION
The current default behavior is to return filesystem corruption errors
and stay "writable". This seems reasonable, but there's been a history
of remounting read-only on error, so it was surprising when the failure
changed. This restores the failure mode. F2FS does not have a similar
option, so only set it for ext4.
