### PR TITLE
Test with Elixir 1.18; fix deprecation warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,16 @@
 version: 2.1
 
 latest: &latest
-  pattern: "^1.17.*-erlang-27.*$"
+  pattern: "^1.18.*-erlang-27.*$"
 
 tags: &tags
   [
+    1.18.0-erlang-27.2-alpine-3.20.3,
     1.17.3-erlang-27.2-alpine-3.20.3,
-    1.16.0-erlang-26.2.1-alpine-3.18.4,
-    1.15.7-erlang-26.1.2-alpine-3.18.4,
+    1.16.3-erlang-26.2.5-alpine-3.20.0,
+    1.15.7-erlang-26.2.1-alpine-3.18.4,
     1.14.5-erlang-25.3.2-alpine-3.18.0,
-    1.13.4-erlang-25.3.2-alpine-3.18.0
+    1.13.4-erlang-24.3.4.11-alpine-3.18.0
   ]
 
 jobs:

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,8 +1,3 @@
-# Always warning as errors
-if Version.match?(System.version(), "~> 1.10") do
-  Code.put_compiler_option(:warnings_as_errors, true)
-end
-
 Logger.configure(level: :error)
 
 ExUnit.start()


### PR DESCRIPTION
This also refreshes the list of other Elixir/Erlang combinations tested
to match the main nerves repository.
