### PR TITLE
Support external modifications to KV

### DIFF
--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -60,7 +60,7 @@ defmodule Nerves.Runtime.KV do
         "b.nerves_fw_version" => "0.1.1",
         "nerves_fw_active" => "b",
         "nerves_fw_devpath" => "/dev/mmcblk0",
-        "nerves_serial_number" => ""
+        "nerves_serial_number" => "123456"
       }
 
   Parts of the firmware metadata are global, while others pertain to a
@@ -157,6 +157,16 @@ defmodule Nerves.Runtime.KV do
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc """
+  Reload the KV store
+
+  This needs to be run if the KV is changed outside of using this module.
+  """
+  @spec reload() :: :ok
+  def reload() do
+    GenServer.call(__MODULE__, :reload)
   end
 
   @doc """
@@ -260,6 +270,10 @@ defmodule Nerves.Runtime.KV do
       |> do_put(s)
 
     {:reply, reply, s}
+  end
+
+  def handle_call(:reload, _from, s) do
+    {:reply, :ok, load(s)}
   end
 
   defp active(s), do: Map.get(s.contents, "nerves_fw_active", "")

--- a/test/nerves_runtime/kv_test.exs
+++ b/test/nerves_runtime/kv_test.exs
@@ -33,7 +33,7 @@ defmodule Nerves.Runtime.KVTest do
     "b.nerves_fw_version" => "0.1.1",
     "nerves_fw_active" => "b",
     "nerves_fw_devpath" => "/dev/mmcblk0",
-    "nerves_serial_number" => ""
+    "nerves_serial_number" => "123456"
   }
 
   setup_all do
@@ -103,6 +103,18 @@ defmodule Nerves.Runtime.KVTest do
 
     assert KV.get_active("active_test_key1") == "active_test_value1"
     assert KV.get_active("active_test_key2") == "active_test_value2"
+  end
+
+  test "reload/1" do
+    # Check the basics and set the serial number to something else
+    assert KV.get("nerves_serial_number") == "123456"
+    KV.put("nerves_serial_number", "654321")
+    assert KV.get("nerves_serial_number") == "654321"
+
+    KV.reload()
+
+    # Check that the serial number is back to the original value
+    assert KV.get("nerves_serial_number") == "123456"
   end
 
   @tag kv_options: [{:modules, [{Nerves.Runtime.KV.Mock, %{"key" => "value"}}]}]


### PR DESCRIPTION
This makes it possible to programmatically reload the cached KV values after an
external program like `fwup` modifies them. This is needed for using `fwup` to
validate or revert firmware since `fwup` runs outside of Elixir.
