### PR TITLE
Document application config and make official

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,22 @@ Task             | Description
 `status`         | Print the active firmware slot (lowercase `a`-`z`) and optionally the one for the next boot. Examples: `a`, `b`, `a->b`.
 `validate`       | Mark the currently running firmware slot as good so that it's booted in the future.
 
+## Application environment
+
+This section documents officially supported application environment keys.
+
+Most users shouldn't need to modify the application environment for
+`nerves_runtime` except for unit testing. See the next section for testing.
+
+Key             | Default                             | Description
+--------------- | ----------------------------------- | ------------
+`:boardid_path` | `"/usr/bin/boardid"`                | Path to the `boardid` binary for determining the device's serial number
+`:devpath`      | `/dev/rootdisk0`                    | The block device that firmware is stored on. `/dev/rootdisk0` is a symlink on Nerves to the real location, so this really shouldn't need to be changed.
+`:fwup_env`     | `%{}`                               | Additional environment variables to pass to `fwup`
+`:fwup_path`    | `"fwup"`                            | Path to the `fwup` binary for querying or modifying firmware status
+`:kv_backend`   | `Nerves.Runtime.KVBackend.UBootEnv` | The backing store for firmware slot and other low level key-value pairs. This is almost always a U-Boot environment block for Nerves
+`:ops_fw_path`  | `"/usr/share/fwup/ops.fw"`          | Path to the `ops.fw` file for passing to `fwup` for firmware status tasks
+
 ## Using nerves_runtime in tests
 
 Applications that depend on `nerves_runtime` for accessing provisioning

--- a/lib/nerves_runtime/fwup_ops.ex
+++ b/lib/nerves_runtime/fwup_ops.ex
@@ -22,7 +22,7 @@ defmodule Nerves.Runtime.FwupOps do
   General options for utilities
 
   * `:devpath` - The location of the storage device (defaults to `"/dev/rootdisk0"`)
-  * `:env` - Additional environment variables to pass to `fwup`
+  * `:fwup_env` - Additional environment variables to pass to `fwup`
   * `:fwup_path` - The path to the `fwup` utility
   * `:ops_fw_path` - The path to the `ops.fw` file (defaults to `"/usr/share/fwup/ops.fw"`)
   * `:reboot` - Call `Nerves.Runtime.reboot/0` after running (defaults to
@@ -30,7 +30,7 @@ defmodule Nerves.Runtime.FwupOps do
   """
   @type options() :: [
           devpath: String.t(),
-          env: %{String.t() => String.t()},
+          fwup_env: %{String.t() => String.t()},
           fwup_path: String.t(),
           ops_fw_path: String.t(),
           reboot: boolean()
@@ -137,7 +137,7 @@ defmodule Nerves.Runtime.FwupOps do
 
   defp run_fwup(task, opts) do
     devpath = Keyword.get(opts, :devpath, "/dev/rootdisk0")
-    cmd_opts = [env: Keyword.get(opts, :env, %{})]
+    cmd_opts = [env: Keyword.get(opts, :fwup_env, %{})]
 
     with {:ok, ops_fw} <- ops_fw_path(opts),
          {:ok, fwup} <- fwup_path(opts) do
@@ -182,7 +182,7 @@ defmodule Nerves.Runtime.FwupOps do
   end
 
   defp ops_fw_path(opts) do
-    app_path = Application.get_env(:nerves_runtime, :revert_fw_path)
+    app_path = Application.get_env(:nerves_runtime, :ops_fw_path)
     overridden_path = opts[:ops_fw_path]
 
     cond do

--- a/mix.exs
+++ b/mix.exs
@@ -23,9 +23,11 @@ defmodule Nerves.Runtime.MixProject do
     [
       env: [
         boardid_path: "/usr/bin/boardid",
+        devpath: "/dev/rootdisk0",
+        fwup_env: %{},
         fwup_path: "fwup",
-        revert_fw_path: "/usr/share/fwup/revert.fw",
-        kv_backend: kv_backend(Mix.target())
+        kv_backend: kv_backend(Mix.target()),
+        ops_fw_path: "/usr/share/fwup/ops.fw"
       ],
       extra_applications: [:logger],
       mod: {Nerves.Runtime.Application, []}

--- a/test/nerves_runtime/fwup_ops_test.exs
+++ b/test/nerves_runtime/fwup_ops_test.exs
@@ -17,7 +17,7 @@ defmodule NervesRuntime.FwupOpsTest do
   setup do
     # Even though this can be specified via an option, use the Application environment
     # since that's how it's normally set in practice.
-    Application.put_env(:nerves_runtime, :revert_fw_path, Path.expand("test/fixture/ops.fw"))
+    Application.put_env(:nerves_runtime, :ops_fw_path, Path.expand("test/fixture/ops.fw"))
     :ok
   end
 
@@ -54,7 +54,7 @@ defmodule NervesRuntime.FwupOpsTest do
   end
 
   defp status_ops(status) do
-    Keyword.put(@fwup_options, :env, %{"STATUS" => status})
+    Keyword.put(@fwup_options, :fwup_env, %{"STATUS" => status})
   end
 
   test "status" do
@@ -68,7 +68,7 @@ defmodule NervesRuntime.FwupOpsTest do
   end
 
   test "missing ops.fw" do
-    Application.put_env(:nerves_runtime, :revert_fw_path, "/does/not/exist/missing_ops.fw")
+    Application.put_env(:nerves_runtime, :ops_fw_path, "/does/not/exist/missing_ops.fw")
 
     assert {:error, "ops.fw or revert.fw not found in Nerves system"} =
              FwupOps.validate(@fwup_options)


### PR DESCRIPTION
The application config had been commonly used in host builds, but never
officially documented. This changes that and fixes two app environment
keys that had unfortunate names, `:env` to `:fwup_env` and
`:revert_fw_path` to `:ops_fw_path`. These really should only have been
used for Nerves.Runtime unit tests.
