### PR TITLE
Add firmware_slots/0 to get the active and next firmware slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Task             | Description
 `prevent-revert` | Make it impossible to revert to the previous partition in the future. This should erase the non-running firmware slot.
 `revert`         | Switch to the previous firmware slot on the next boot.
 `status`         | Print the active firmware slot (lowercase `a`-`z`) and optionally the one for the next boot. Examples: `a`, `b`, `a->b`.
-`validate`       | Mark the currently running firmware slot as good so that it's booted in the future.
+`validate`       | Mark the actively running firmware slot as good so that it's booted in the future.
 
 ## Application environment
 

--- a/lib/nerves_runtime/fwup_ops.ex
+++ b/lib/nerves_runtime/fwup_ops.ex
@@ -85,7 +85,7 @@ defmodule Nerves.Runtime.FwupOps do
   end
 
   @doc """
-  Validate the current partition
+  Validate the active partition
 
   For Nerves systems that support automatic rollback of firmware versions, this
   marks the partition as good so that it will continue to be used on future
@@ -129,12 +129,12 @@ defmodule Nerves.Runtime.FwupOps do
   @doc """
   Return boot status
 
-  This invokes the "status" task in the `ops.fw` to report the current
+  This invokes the "status" task in the `ops.fw` to report the active
   firmware slot and what slot will be tried on the next reboot. The `ops.fw`
   is expected to print the slot name or two slot names separated by "->".
   """
   @spec status(options()) ::
-          {:ok, %{current: String.t(), next: String.t()}} | {:error, reason :: any}
+          {:ok, %{active: String.t(), next: String.t()}} | {:error, reason :: any}
   def status(opts \\ []) do
     with {:ok, raw_result} <- call_run_fwup("status", opts),
          {:ok, result} <- deframe(raw_result, []) do
@@ -142,10 +142,10 @@ defmodule Nerves.Runtime.FwupOps do
     end
   end
 
-  defp find_status({:warning, <<slot::1-bytes>>}), do: {:ok, %{current: slot, next: slot}}
+  defp find_status({:warning, <<slot::1-bytes>>}), do: {:ok, %{active: slot, next: slot}}
 
-  defp find_status({:warning, <<current::1-bytes, "->", next::1-bytes>>}),
-    do: {:ok, %{current: current, next: next}}
+  defp find_status({:warning, <<active::1-bytes, "->", next::1-bytes>>}),
+    do: {:ok, %{active: active, next: next}}
 
   defp find_status(_status), do: nil
 

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -328,7 +328,7 @@ defmodule Nerves.Runtime.KV do
   defp refresh_active(s) do
     active =
       case FwupOps.status() do
-        {:ok, %{current: active}} -> active
+        {:ok, %{active: active}} -> active
         {:error, _reason} -> s.contents["nerves_fw_active"] || "a"
       end
 

--- a/test/nerves_runtime/fwup_ops_test.exs
+++ b/test/nerves_runtime/fwup_ops_test.exs
@@ -87,9 +87,9 @@ defmodule NervesRuntime.FwupOpsTest do
 
     test "success", context do
       # ops-status.conf lets you set the status via $STATUS
-      assert {:ok, %{current: "a", next: "b"}} = fwup_status(context, "a->b")
-      assert {:ok, %{current: "b", next: "a"}} = fwup_status(context, "b->a")
-      assert {:ok, %{current: "c", next: "c"}} = fwup_status(context, "c")
+      assert {:ok, %{active: "a", next: "b"}} = fwup_status(context, "a->b")
+      assert {:ok, %{active: "b", next: "a"}} = fwup_status(context, "b->a")
+      assert {:ok, %{active: "c", next: "c"}} = fwup_status(context, "c")
       assert {:error, "Invalid status"} = fwup_status(context, "xyz")
     end
 


### PR DESCRIPTION
This also settles on referring to the slot providing the firmware that's running as `active`. The references to `current` were all updated.