### PR TITLE
Add support for checking if the previous firmware was reverted

### DIFF
--- a/lib/nerves_runtime.ex
+++ b/lib/nerves_runtime.ex
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2018 Michał Kalbarczyk
 # SPDX-FileCopyrightText: 2020 Connor Rigby
 # SPDX-FileCopyrightText: 2020 Jon Carstens
+# SPDX-FileCopyrightText: 2025 Josh Kalderimis
 #
 # SPDX-License-Identifier: Apache-2.0
 defmodule Nerves.Runtime do
@@ -184,6 +185,19 @@ defmodule Nerves.Runtime do
       :unvalidated -> false
       :unknown -> true
     end
+  end
+
+  @doc """
+  Return whether the previous firmware was reverted
+
+  Support for `nerves_fw_reverted` is new and requires Nerves systems to
+  implement the KV markers in Fwup and/or U-Boot.
+
+  If `nerves_fw_reverted` is not set, it is assumed that the firmware was not reverted.
+  """
+  @spec firmware_reverted?() :: boolean()
+  def firmware_reverted?() do
+    KV.get("nerves_fw_reverted") == "1"
   end
 
   defp validation_status() do

--- a/lib/nerves_runtime/kv.ex
+++ b/lib/nerves_runtime/kv.ex
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2018 Connor Rigby
 # SPDX-FileCopyrightText: 2019 Jon Carstens
 # SPDX-FileCopyrightText: 2019 Troels Brødsgaard
+# SPDX-FileCopyrightText: 2025 Josh Kalderimis
 #
 # SPDX-License-Identifier: Apache-2.0
 defmodule Nerves.Runtime.KV do
@@ -68,14 +69,15 @@ defmodule Nerves.Runtime.KV do
         "b.nerves_fw_version" => "0.1.1",
         "nerves_fw_active" => "b",
         "nerves_fw_devpath" => "/dev/mmcblk0",
+        "nerves_fw_reverted" => "0",
         "nerves_serial_number" => "123456"
       }
 
   Parts of the firmware metadata are global, while others pertain to a
   specific firmware slot. This is indicated by the key - data which describes
   firmware of a specific slot have keys prefixed with the name of the
-  firmware slot. In the above example, `"nerves_fw_active"` and
-  `"nerves_serial_number"` are global, while `"a.nerves_fw_version"` and
+  firmware slot. In the above example, `"nerves_fw_active"`, `"nerves_fw_reverted"`,
+  and `"nerves_serial_number"` are global, while `"a.nerves_fw_version"` and
   `"b.nerves_fw_version"` apply to the "a" and "b" firmware slots,
   respectively.
 

--- a/test/nerves_runtime/kv_test.exs
+++ b/test/nerves_runtime/kv_test.exs
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2017 Justin Schneck
 # SPDX-FileCopyrightText: 2018 Frank Hunleth
 # SPDX-FileCopyrightText: 2022 Jon Carstens
+# SPDX-FileCopyrightText: 2025 Josh Kalderimis
 #
 # SPDX-License-Identifier: Apache-2.0
 defmodule Nerves.Runtime.KVTest do
@@ -38,6 +39,7 @@ defmodule Nerves.Runtime.KVTest do
     "b.nerves_fw_version" => "0.1.1",
     "nerves_fw_active" => "b",
     "nerves_fw_devpath" => "/dev/mmcblk0",
+    "nerves_fw_reverted" => "0",
     "nerves_serial_number" => "123456"
   }
 

--- a/test/nerves_runtime_test.exs
+++ b/test/nerves_runtime_test.exs
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2017 Frank Hunleth
 # SPDX-FileCopyrightText: 2017 Justin Schneck
+# SPDX-FileCopyrightText: 2025 Josh Kalderimis
 #
 # SPDX-License-Identifier: Apache-2.0
 defmodule NervesRuntimeTest do
@@ -153,6 +154,19 @@ defmodule NervesRuntimeTest do
       assert KV.get("b.nerves_fw_validated") == "1"
       assert Nerves.Runtime.firmware_valid?()
       assert Nerves.Runtime.firmware_slots() == %{active: "b", next: "b"}
+    end
+  end
+
+  describe "firmware reverted" do
+    test "firmware_reverted?" do
+      # no value for `nerves_fw_reverted` exists
+      refute Nerves.Runtime.firmware_reverted?()
+
+      KV.put(%{"nerves_fw_reverted" => "0"})
+      refute Nerves.Runtime.firmware_reverted?()
+
+      KV.put(%{"nerves_fw_reverted" => "1"})
+      assert Nerves.Runtime.firmware_reverted?()
     end
   end
 


### PR DESCRIPTION
This add support, on the runtime side, for detecting if the previous firmware was reverted using a new U-Boot env var called `nerves_fw_reverted`.

This env var would be added to `fwup-ops.conf` and `uboot.env` files in Nerves systems. 

Without this env var, the `firmware_reverted?` function will return false.

This env var would allow for MOTD to display information regarding if the previous firmware was reverted, and NervesHubLink can turn this into an alarm, which will then be sent to NervesHub in the form of a health report.