### PR TITLE
Sync `nerves_fw_active` during KV load if needed

### DIFF
--- a/test/nerves_runtime/kv_test.exs
+++ b/test/nerves_runtime/kv_test.exs
@@ -122,6 +122,13 @@ defmodule Nerves.Runtime.KVTest do
     assert KV.get("nerves_serial_number") == "123456"
   end
 
+  @tag kv_options: [
+         kv_backend: {Nerves.Runtime.KVBackend.InMemory, contents: %{}}
+       ]
+  test "sync active fw information" do
+    assert KV.get("nerves_fw_active") == "a"
+  end
+
   @tag kv_options: [{:modules, [{Nerves.Runtime.KV.Mock, %{"key" => "value"}}]}]
   test "old modules configuration" do
     assert KV.get("key") == "value"
@@ -139,8 +146,8 @@ defmodule Nerves.Runtime.KVTest do
   end
 
   @tag kv_options: [kv_backend: Nerves.Runtime.KVBackend.InMemory]
-  test "empty configuration" do
-    assert KV.get_all() == %{}
+  test "empty configuration includes calculated nerves_fw_active value" do
+    assert KV.get_all() == %{"nerves_fw_active" => "a"}
   end
 
   @tag kv_options: [kv_backend: Nerves.Runtime.KVBackend.BadBad]


### PR DESCRIPTION
It's possible for the `nerves_fw_active` information in the KV to become out of date. 

This PR syncs `nerves_fw_active` in the KV if it differs from what's returned by `FwupOps.status()`

This PR is a companion to https://github.com/nerves-project/nerves_system_rpi4/pull/289

If the above PR is merged in, one use case where the active slot and `nerves_fw_active` can be out of sync is after a Raspberry Pi `tryboot` revert.

I've tested these two PRs on my local device connected to NervesCloud and everything is reporting correctly, including in MOTD (I'm using `nerves_motd` from hex).