### PR TITLE
Allow for args to be passed to `rngd` and `haveged`

### DIFF
--- a/lib/nerves_runtime/application.ex
+++ b/lib/nerves_runtime/application.ex
@@ -57,8 +57,9 @@ defmodule Nerves.Runtime.Application do
       path = "/usr/sbin/#{name}"
 
       if File.exists?(path) do
+        args = Application.get_env(:nerves_runtime, String.to_atom("#{name}_args"), [])
         # Launch rngd/haveged. They daemonize themselves so this should return quickly.
-        case System.cmd(path, []) do
+        case System.cmd(path, args) do
           {_, 0} ->
             true
 


### PR DESCRIPTION
This is especially useful for rngd where you may want to disable a source, or pass in a config for another source. For example, while I was investigating some error messages found in dmesg for my Compulab IOT-Gate board, I found that several sources were detected but none were available. This PR allowed me to pass in args to disable many of the sources configured during Nerves.Runtime startup.