### PR TITLE
Allow for the entropy generators to be skipped

### DIFF
--- a/lib/nerves_runtime/application.ex
+++ b/lib/nerves_runtime/application.ex
@@ -46,7 +46,9 @@ defmodule Nerves.Runtime.Application do
       # numbers.
       # On systems with no hardware random number generation, or where rngd is
       # not installed, haveged is tried as an alternative.
-      try_entropy_generator("rngd") || try_entropy_generator("haveged")
+      # Allow for these checks to be skipped if desired.
+      Application.get_env(:nerves_runtime, :skip_entropy_generator_checks, false) ||
+        try_entropy_generator("rngd") || try_entropy_generator("haveged")
 
       _ = try_load_sysctl_conf()
 


### PR DESCRIPTION
`rngd` and `haveged` are not required with modern kernels (https://blogs.oracle.com/linux/post/entropyavail-256-is-good-enough-for-everyone and https://superuser.com/questions/1735726/does-rngd-accept-other-entropy-input-with-debian11-kernel-debian-5-10-0-17/1735729#1735729)

With some boards, like the Compulabs IOT-Gate, `rngd` will detect a handful of strategies, but fail to initalize all of them (except when the TPM module is plugged in, but that is picked up as a hardware entropy source). So running `rndg` doesn't really work, and it isn't needed based on recent linux advice.

This PR was initially part of #389 but was closed as the feedback to remove `rngd` was perfectly valid. Sadly, after looking into this, `rng-tools` can't be removed because it is a dependency of [`nerves_system_br`](https://github.com/nerves-project/nerves_system_br/blob/98a41eb6392c40dabf6462dffc67d804f2454d1a/package/nerves-config/Config.in#L13C9-L13C30) (and [here](https://github.com/nerves-project/nerves_system_br/blob/main/package/nerves-config/nerves-config.mk#L12C109-L12C118))