### PR TITLE
Update HexDoc URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,7 +199,7 @@ This is a major update to `nerves_runtime` that removes SystemRegistry.
 SystemRegistry has been disabled by default for years, but it could be
 re-enabled if device insertion and removal events were needed. That
 functionality has been moved to
-[`nerves_uevent`](https://hexdocs.pm/nerves_uevent/readme.html) and updated to
+[`nerves_uevent`](https://nerves-uevent.hexdocs.pm/readme.html) and updated to
 use the `property_table` library used by VintageNet.
 
 Elixir 1.11 is the minimum supported Elixir version now.
@@ -220,7 +220,7 @@ To upgrade from prior versions of `nerves_runtime`:
 
 * Changes
   * Kernel logging and syslog monitoring has been moved to
-    [`nerves_logging`](https://hexdocs.pm/nerves_logging/readme.html). The
+    [`nerves_logging`](https://nerves-logging.hexdocs.pm/readme.html). The
     functionality is the same as before, but it's now possible to use without
     `nerves_runtime`.
   * Added convenience routines for getting status from

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # nerves_runtime
 
 [![Hex version](https://img.shields.io/hexpm/v/nerves_runtime.svg "Hex version")](https://hex.pm/packages/nerves_runtime)
-[![API docs](https://img.shields.io/hexpm/v/nerves_runtime.svg?label=hexdocs "API docs")](https://hexdocs.pm/nerves_runtime/Nerves.Runtime.html)
+[![API docs](https://img.shields.io/hexpm/v/nerves_runtime.svg?label=hexdocs "API docs")](https://nerves-runtime.hexdocs.pm/Nerves.Runtime.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-project/nerves_runtime/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-project/nerves_runtime/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/nerves_runtime)](https://api.reuse.software/info/github.com/nerves-project/nerves_runtime)
 
@@ -25,7 +25,7 @@ Here are its features:
 * Linux log integration with Elixir. See [`nerves_logging`](https://github.com/nerves-project/nerves_logging)
 
 The following sections describe the features in more detail. For more
-information, see the [hex docs](https://hexdocs.pm/nerves_runtime).
+information, see the [hex docs](https://nerves-runtime.hexdocs.pm).
 
 ## System Initialization
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-uevent.hexdocs.pm/readme.html): Status 404
❌ Verification failed for https://nerves-logging.hexdocs.pm/readme.html): Status 404
❌ Verification failed for https://nerves-runtime.hexdocs.pm/Nerves.Runtime.html): Status 404
❌ Verification failed for https://nerves-runtime.hexdocs.pm): %Req.TransportError{reason: :nxdomain}
⚠️ Verification finished: 0 success, 4 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>